### PR TITLE
Fix Kolibri digits integration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,20 @@
+```kolibri-policy
+build: ours
+code: ours
+docs: ours
+
+files:
+  prefer_ours:
+    - backend/**
+    - frontend/**
+    - scripts/**
+  prefer_theirs:
+    - docs/**
+    - README.md
+
+budgets:
+  wasm_max_kb: 6144
+  step_latency_ms: 250
+  coverage_min_lines: 75
+  coverage_min_branches: 60
+```

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ add_library(kolibri_core
     backend/src/formula.c
     backend/src/roy.c
     backend/src/script.c
+    backend/src/net.c
 )
 
 target_include_directories(kolibri_core
@@ -42,6 +43,7 @@ if(KOLIBRI_ENABLE_TESTS)
         tests/test_formula.c
         tests/test_roy.c
         tests/test_script.c
+        tests/test_net.c
     )
     target_link_libraries(kolibri_tests PRIVATE kolibri_core Threads::Threads)
     add_test(NAME kolibri_tests COMMAND kolibri_tests)

--- a/apps/ks_compiler.c
+++ b/apps/ks_compiler.c
@@ -3,6 +3,7 @@
  */
 
 #include "kolibri/decimal.h"
+#include "kolibri/digits.h"
 
 #include <errno.h>
 #include <stdbool.h>
@@ -188,7 +189,7 @@ static int kodirovat(const char *vyhod, const unsigned char *vhod,
         return -1;
     }
     for (size_t indeks = 0U; indeks < potok.dlina; ++indeks) {
-        stroka[indeks] = (char)('0' + potok.cifry[indeks]);
+        stroka[indeks] = (char)('0' + potok.danniye[indeks]);
     }
     stroka[potok.dlina] = '\n';
     stroka[potok.dlina + 1U] = '\0';

--- a/backend/include/kolibri/script.h
+++ b/backend/include/kolibri/script.h
@@ -1,11 +1,11 @@
 /*
-#include "kolibri/digits.h"
  * Copyright (c) 2025 Кочуров Владислав Евгеньевич
  */
 
 #ifndef KOLIBRI_SCRIPT_H
 #define KOLIBRI_SCRIPT_H
 
+#include "kolibri/digits.h"
 #include "kolibri/decimal.h"
 #include "kolibri/formula.h"
 #include "kolibri/genome.h"

--- a/tests/test_digits.c
+++ b/tests/test_digits.c
@@ -3,16 +3,15 @@
 #include <string.h>
 #include <stdio.h>
 
-int main(void){
+void test_digits(void) {
     uint8_t buf[1024]; kolibri_potok_cifr p;
     assert(kolibri_potok_cifr_init(&p, buf, sizeof(buf)) == 0);
     const char *msg = "Privet, Kolibri!";
     size_t n = strlen(msg);
-    assert(kolibri_transducirovat_utf8(&p, (const uint8_t*)msg, n) == 0);
+    assert(kolibri_transducirovat_utf8(&p, (const uint8_t *)msg, n) == 0);
     assert(p.dlina == kolibri_dlina_kodirovki_teksta(n));
-    uint8_t out[256]; size_t w=0;
+    uint8_t out[256]; size_t w = 0;
     assert(kolibri_izluchit_utf8(&p, out, sizeof(out), &w) == 0);
     assert(w == n && memcmp(out, msg, n) == 0);
     puts("digits ok");
-    return 0;
 }

--- a/tests/test_kolibri_sim.py
+++ b/tests/test_kolibri_sim.py
@@ -9,9 +9,9 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-import pytest
+import pytest  # noqa: E402
 
-from core.kolibri_sim import (
+from core.kolibri_sim import (  # noqa: E402
     KolibriSim,
     dec_hash,
     dolzhen_zapustit_repl,

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -4,11 +4,13 @@ void test_decimal(void);
 void test_genome(void);
 void test_formula(void);
 void test_net(void);
+void test_digits(void);
 
 int main(void) {
   test_decimal();
   test_genome();
   test_formula();
+  test_digits();
   test_net();
   printf("all tests passed\n");
   return 0;

--- a/tests/test_script.c
+++ b/tests/test_script.c
@@ -65,7 +65,7 @@ static void zapisat_cifrovyj_skript(char *path, size_t path_dlina,
     FILE *file = fdopen(fd, "wb");
     assert(file != NULL);
     for (size_t indeks = 0; indeks < potok.dlina; ++indeks) {
-        fputc('0' + potok.cifry[indeks], file);
+        fputc('0' + potok.danniye[indeks], file);
     }
     fclose(file);
 }


### PR DESCRIPTION
## Summary
- ensure the KolibriScript API pulls in the digits types and update tests to use the new buffer field
- add the network module and digits/unit tests to the CMake targets so the suite links and runs correctly
- include Kolibri digits helpers in ks_compiler so script encoding succeeds again

## Testing
- cmake --build build --target ks_compiler
- ctest --test-dir build


------
https://chatgpt.com/codex/tasks/task_e_68d8502e2fbc8323b7f3f56974caf4f9