### PR TITLE
Document Python tooling dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,13 @@
 
 ## Быстрый старт
 1. Клонируйте репозиторий и перейдите в директорию проекта.
-2. Создайте виртуальное окружение:
+2. Подготовьте виртуальное окружение Python (поддерживаются версии 3.10+):
    ```bash
    python -m venv .venv
    source .venv/bin/activate  # Windows: .venv\\Scripts\\activate
+   python -m pip install --upgrade pip
    ```
-3. Установите зависимости Python:
+3. Установите инструменты, перечисленные в [`requirements.txt`](requirements.txt). Файл включает точные версии `pytest`, `coverage`, `ruff` и `pyright`, которые используются в CI.
    ```bash
    pip install -r requirements.txt
    ```
@@ -24,9 +25,11 @@
    cmake -S . -B build -G "Ninja"  # или опустите -G, чтобы использовать Makefiles
    cmake --build build
    ```
-5. Запустите тесты:
+5. Запустите тесты и проверки качества Python:
    ```bash
    pytest -q
+   ruff check .
+   pyright
    ctest --test-dir build
    ```
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-# Kolibri's Python tooling currently relies on standalone scripts.
-# This placeholder keeps GitHub Actions' pip cache step happy by
-# presenting a dependency manifest even though no runtime packages
-# are required.
+# Инструменты Python, используемые Kolibri OS для тестов и статического анализа.
+coverage[toml]>=7.4,<8
+pyright>=1.1.350,<1.2
+pytest>=7.4,<9
+ruff>=0.4.0,<0.5


### PR DESCRIPTION
## Summary
- declare the Python tooling dependencies with version ranges in requirements.txt
- refresh the quick start instructions to describe the virtual environment setup and reference the new dependency specification

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d9438921388323ab0b4d7a829f4b0c