### PR TITLE
Add wasm copy step for frontend build pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,17 @@ jobs:
           emsdk-version: latest
       - name: Сборка kolibri.wasm
         run: ./scripts/build_wasm.sh
+      - name: Подготовка wasm для предпросмотра фронтенда
+        run: |
+          mkdir -p preview-artifacts
+          cp build/wasm/kolibri.wasm preview-artifacts/kolibri.wasm
+      - name: Публикация wasm для предпросмотра фронтенда
+        uses: actions/upload-artifact@v4
+        with:
+          name: frontend-preview-wasm
+          path: preview-artifacts/kolibri.wasm
+          if-no-files-found: error
+          retention-days: 7
       - name: Публикация артефактов WASM
         uses: actions/upload-artifact@v4
         with:

--- a/README.md
+++ b/README.md
@@ -24,7 +24,17 @@
    cmake -S . -B build -G "Ninja"  # или опустите -G, чтобы использовать Makefiles
    cmake --build build
    ```
-5. Запустите тесты:
+5. Для веб-интерфейса соберите wasm-ядро перед фронтендом:
+   ```bash
+   ./scripts/build_wasm.sh
+   ```
+6. Соберите фронтенд (после установки npm-зависимостей в `frontend/`):
+   ```bash
+   cd frontend
+   npm install
+   npm run build
+   ```
+7. Запустите тесты:
    ```bash
    pytest -q
    ctest --test-dir build

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,8 +1,46 @@
-import { defineConfig } from "vite";
+import { defineConfig, type Plugin } from "vite";
 import react from "@vitejs/plugin-react";
+import { copyFile, mkdir, access } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+function copyKolibriWasm(): Plugin {
+  const frontendDir = fileURLToPath(new URL(".", import.meta.url));
+  const wasmSource = resolve(frontendDir, "../build/wasm/kolibri.wasm");
+  const publicTarget = resolve(frontendDir, "public/kolibri.wasm");
+  let copied = false;
+
+  const performCopy = async () => {
+    if (copied) {
+      return;
+    }
+
+    try {
+      await access(wasmSource);
+    } catch (error) {
+      throw new Error(
+        `[copy-kolibri-wasm] Не найден ${wasmSource}. Запустите scripts/build_wasm.sh перед npm run build.`,
+      );
+    }
+
+    await mkdir(dirname(publicTarget), { recursive: true });
+    await copyFile(wasmSource, publicTarget);
+    copied = true;
+  };
+
+  return {
+    name: "copy-kolibri-wasm",
+    async buildStart() {
+      await performCopy();
+    },
+    async configureServer() {
+      await performCopy();
+    },
+  };
+}
 
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), copyKolibriWasm()],
   server: {
     port: 5173,
   },


### PR DESCRIPTION
## Summary
- add a Vite plugin that copies build/wasm/kolibri.wasm into the public assets and surfaces a helpful error when the file is missing
- extend the README quick start guide with the WebAssembly build prerequisite before running the frontend build
- publish a dedicated kolibri.wasm artifact from the wasm-build workflow for use by frontend preview jobs

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d94397da6c8323abb2451a6f715f74