### PR TITLE
Implement boot image packaging, SLIP networking, and RAM disk support

### DIFF
--- a/boot/kolibri.asm
+++ b/boot/kolibri.asm
@@ -1,0 +1,204 @@
+; Kolibri OS загрузчик: читает ядро с диска в память, подготавливает
+; конфигурацию и передаёт управление точке входа ядра в защищённом режиме.
+
+BITS 16
+ORG 0x7C00
+
+start:
+    cli
+    xor ax, ax
+    mov ds, ax
+    mov es, ax
+    mov ss, ax
+    mov sp, 0x7C00
+
+    mov [boot_drive], dl
+    mov word [destination_segment], 0x1000
+    mov word [destination_offset], 0
+
+    mov si, welcome_msg
+    call bios_print
+
+    mov di, [kernel_sectors]
+    mov si, 1               ; LBA = 1 (сектор после загрузчика)
+
+load_loop:
+    cmp di, 0
+    je load_done
+    push di
+    push si
+    call read_sector
+    jc disk_error
+    pop si
+    inc si
+    pop di
+    dec di
+    jmp load_loop
+
+load_done:
+    mov ax, 0x0040
+    mov es, ax
+    mov word [es:0x0072], 0 ; BIOS warm boot flag -> холодный старт после возврата
+
+    mov ax, 0x0000
+    mov es, ax
+    mov dword [0x8000], 20250923
+    mov dword [0x8004], 1
+    mov word  [0x8008], 0x1F90
+    mov word  [0x800A], 0
+
+    call enable_a20
+    call enter_protected_mode
+
+disk_error:
+    mov si, disk_msg
+    call bios_print
+hang:
+    hlt
+    jmp hang
+
+; --- BIOS helper routines ---
+
+bios_print:
+    lodsb
+    cmp al, 0
+    je .done
+    mov ah, 0x0E
+    mov bh, 0
+    mov bl, 0x07
+    int 0x10
+    jmp bios_print
+.done:
+    ret
+
+read_sector:
+    push ax
+    push bx
+    push cx
+    push dx
+    push si
+
+    mov ax, si
+    call lba_to_chs
+    mov ah, 0x02
+    mov al, 1
+    mov ch, byte [chs_cylinder]
+    mov cl, byte [chs_sector]
+    mov dh, byte [chs_head]
+    mov dl, [boot_drive]
+    mov bx, [destination_offset]
+    mov es, word [destination_segment]
+    int 0x13
+    jc .fail
+    add word [destination_offset], 512
+    cmp word [destination_offset], 0
+    jne .ok
+    add word [destination_segment], 0x20
+.ok:
+    clc
+    jmp .done
+.fail:
+    stc
+.done:
+    pop si
+    pop dx
+    pop cx
+    pop bx
+    pop ax
+    ret
+
+lba_to_chs:
+    xor dx, dx
+    mov bx, 18               ; секторов на дорожке
+    div bx
+    mov byte [chs_sector], dl
+    xor dx, dx
+    mov bx, 2
+    div bx
+    mov byte [chs_head], dl
+    mov byte [chs_cylinder], al
+    inc byte [chs_sector]
+    ret
+
+enable_a20:
+    in al, 0x64
+.wait_input:
+    test al, 0x02
+    jnz .wait_input
+    mov al, 0xD1
+    out 0x64, al
+.wait_ready:
+    in al, 0x64
+    test al, 0x02
+    jnz .wait_ready
+    mov al, 0xDF
+    out 0x60, al
+    ret
+
+enter_protected_mode:
+    cli
+    lgdt [gdt_descriptor]
+    mov eax, cr0
+    or eax, 0x1
+    mov cr0, eax
+    jmp 0x08:protected_entry
+
+; --- Protected mode section ---
+
+BITS 32
+
+protected_entry:
+    mov ax, 0x10
+    mov ds, ax
+    mov es, ax
+    mov fs, ax
+    mov gs, ax
+    mov ss, ax
+    mov esp, 0x00900000
+
+    mov esi, 0x00010000
+    mov edi, 0x00100000
+    mov ecx, [kernel_bytes]
+    mov ebx, ecx
+    shr ecx, 2
+    rep movsd
+    mov ecx, ebx
+    and ecx, 3
+    rep movsb
+
+    mov eax, 0x36D76289
+    xor ebx, ebx
+    mov esi, 0x00008000
+    jmp 0x08:0x00100000
+
+; --- Data ---
+
+BITS 16
+
+boot_drive:             db 0
+destination_segment:    dw 0x1000
+destination_offset:     dw 0x0000
+chs_sector:             db 0
+chs_head:               db 0
+chs_cylinder:           db 0
+kernel_marker:          db 'KSEC'
+kernel_sectors:         dw 0
+kernel_bytes_marker:    db 'KBYT'
+kernel_bytes:           dd 0
+
+welcome_msg: db "Kolibri loader", 0
+disk_msg:    db "Disk error", 0
+
+align 16
+gdt_start:
+    dq 0x0000000000000000
+    dq 0x00CF9A000000FFFF
+    dq 0x00CF92000000FFFF
+gdt_end:
+
+gdt_descriptor:
+    dw gdt_end - gdt_start - 1
+    dd gdt_start
+
+times 510-($-$$) db 0
+dw 0xAA55

--- a/kernel/formula.c
+++ b/kernel/formula.c
@@ -1,0 +1,235 @@
+#include "kolibri/formula.h"
+
+#include "support.h"
+
+#define KOLIBRI_FORMULA_CAPACITY (sizeof(((KolibriFormulaPool *)0)->formulas) / sizeof(KolibriFormula))
+
+static uint8_t random_digit(KolibriFormulaPool *pool) {
+    return (uint8_t)(k_rng_next(&pool->rng) % 10ULL);
+}
+
+static void gene_randomize(KolibriFormulaPool *pool, KolibriGene *gene) {
+    gene->length = sizeof(gene->digits);
+    for (size_t i = 0; i < gene->length; ++i) {
+        gene->digits[i] = random_digit(pool);
+    }
+}
+
+static int decode_coefficients(const KolibriGene *gene, int *slope, int *bias) {
+    if (!gene || !slope || !bias || gene->length < 4U) {
+        return -1;
+    }
+    int raw_slope = (int)(gene->digits[0] * 10 + gene->digits[1]);
+    int raw_bias = (int)(gene->digits[2] * 10 + gene->digits[3]);
+    *slope = (gene->digits[4] % 2U == 0U) ? raw_slope : -raw_slope;
+    *bias = (gene->digits[5] % 2U == 0U) ? raw_bias : -raw_bias;
+    return 0;
+}
+
+static double evaluate_formula(const KolibriFormula *formula, const KolibriFormulaPool *pool) {
+    if (!formula || !pool || pool->examples == 0U) {
+        return 0.0;
+    }
+    int slope = 0;
+    int bias = 0;
+    if (decode_coefficients(&formula->gene, &slope, &bias) != 0) {
+        return 0.0;
+    }
+    double total_error = 0.0;
+    for (size_t i = 0; i < pool->examples; ++i) {
+        int prediction = slope * pool->inputs[i] + bias;
+        int diff = prediction - pool->targets[i];
+        if (diff < 0) {
+            diff = -diff;
+        }
+        total_error += (double)diff;
+    }
+    double normalized = 1.0 / (1.0 + total_error);
+    double adjusted = normalized + formula->feedback;
+    if (adjusted < 0.0) {
+        adjusted = 0.0;
+    }
+    if (adjusted > 1.0) {
+        adjusted = 1.0;
+    }
+    return adjusted;
+}
+
+static void mutate_gene(KolibriFormulaPool *pool, KolibriGene *gene) {
+    if (!gene) {
+        return;
+    }
+    size_t index = (size_t)(k_rng_next(&pool->rng) % gene->length);
+    gene->digits[index] = random_digit(pool);
+}
+
+void kf_pool_init(KolibriFormulaPool *pool, uint64_t seed) {
+    if (!pool) {
+        return;
+    }
+    k_memset(pool, 0, sizeof(*pool));
+    k_rng_seed(&pool->rng, seed);
+    pool->count = KOLIBRI_FORMULA_CAPACITY;
+    for (size_t i = 0; i < pool->count; ++i) {
+        gene_randomize(pool, &pool->formulas[i].gene);
+        pool->formulas[i].fitness = 0.0;
+        pool->formulas[i].feedback = 0.0;
+    }
+}
+
+void kf_pool_clear_examples(KolibriFormulaPool *pool) {
+    if (!pool) {
+        return;
+    }
+    pool->examples = 0U;
+}
+
+int kf_pool_add_example(KolibriFormulaPool *pool, int input, int target) {
+    if (!pool || pool->examples >= sizeof(pool->inputs) / sizeof(pool->inputs[0])) {
+        return -1;
+    }
+    pool->inputs[pool->examples] = input;
+    pool->targets[pool->examples] = target;
+    ++pool->examples;
+    return 0;
+}
+
+static void evaluate_pool(KolibriFormulaPool *pool) {
+    if (!pool) {
+        return;
+    }
+    for (size_t i = 0; i < pool->count; ++i) {
+        pool->formulas[i].fitness = evaluate_formula(&pool->formulas[i], pool);
+    }
+}
+
+static KolibriFormula *select_best(KolibriFormulaPool *pool) {
+    if (!pool || pool->count == 0U) {
+        return NULL;
+    }
+    size_t best_index = 0U;
+    double best_score = pool->formulas[0].fitness;
+    for (size_t i = 1; i < pool->count; ++i) {
+        if (pool->formulas[i].fitness > best_score) {
+            best_score = pool->formulas[i].fitness;
+            best_index = i;
+        }
+    }
+    return &pool->formulas[best_index];
+}
+
+void kf_pool_tick(KolibriFormulaPool *pool, size_t generations) {
+    if (!pool || pool->count == 0U) {
+        return;
+    }
+    for (size_t gen = 0; gen < generations; ++gen) {
+        evaluate_pool(pool);
+        KolibriFormula *best = select_best(pool);
+        for (size_t i = 0; i < pool->count; ++i) {
+            if (&pool->formulas[i] == best) {
+                continue;
+            }
+            if (pool->formulas[i].fitness < 0.5) {
+                k_memcpy(&pool->formulas[i].gene, &best->gene, sizeof(KolibriGene));
+                mutate_gene(pool, &pool->formulas[i].gene);
+            }
+        }
+    }
+    evaluate_pool(pool);
+}
+
+const KolibriFormula *kf_pool_best(const KolibriFormulaPool *pool) {
+    if (!pool || pool->count == 0U) {
+        return NULL;
+    }
+    const KolibriFormula *best = &pool->formulas[0];
+    for (size_t i = 1; i < pool->count; ++i) {
+        if (pool->formulas[i].fitness > best->fitness) {
+            best = &pool->formulas[i];
+        }
+    }
+    return best;
+}
+
+int kf_formula_apply(const KolibriFormula *formula, int input, int *output) {
+    if (!formula || !output) {
+        return -1;
+    }
+    int slope = 0;
+    int bias = 0;
+    if (decode_coefficients(&formula->gene, &slope, &bias) != 0) {
+        return -1;
+    }
+    long long result = (long long)slope * (long long)input + (long long)bias;
+    if (result > 2147483647LL) {
+        result = 2147483647LL;
+    }
+    if (result < -2147483648LL) {
+        result = -2147483648LL;
+    }
+    *output = (int)result;
+    return 0;
+}
+
+size_t kf_formula_digits(const KolibriFormula *formula, uint8_t *out, size_t out_len) {
+    if (!formula || !out || out_len == 0U) {
+        return 0U;
+    }
+    size_t count = formula->gene.length;
+    if (count > out_len) {
+        count = out_len;
+    }
+    k_memcpy(out, formula->gene.digits, count);
+    return count;
+}
+
+int kf_formula_describe(const KolibriFormula *formula, char *buffer, size_t buffer_len) {
+    if (!formula || !buffer || buffer_len == 0U) {
+        return -1;
+    }
+    int slope = 0;
+    int bias = 0;
+    if (decode_coefficients(&formula->gene, &slope, &bias) != 0) {
+        return -1;
+    }
+    char sign = bias >= 0 ? '+' : '-';
+    int abs_bias = bias >= 0 ? bias : -bias;
+    char temp[32];
+    size_t len = 0U;
+    temp[len++] = 'y';
+    temp[len++] = '=';
+    if (slope < 0) {
+        temp[len++] = '-';
+        slope = -slope;
+    }
+    temp[len++] = (char)('0' + (slope / 10) % 10);
+    temp[len++] = (char)('0' + slope % 10);
+    temp[len++] = '*';
+    temp[len++] = 'x';
+    temp[len++] = sign;
+    temp[len++] = (char)('0' + (abs_bias / 10) % 10);
+    temp[len++] = (char)('0' + abs_bias % 10);
+    temp[len] = '\0';
+    k_strlcpy(buffer, temp, buffer_len);
+    return 0;
+}
+
+int kf_pool_feedback(KolibriFormulaPool *pool, const KolibriGene *gene, double delta) {
+    if (!pool || !gene) {
+        return -1;
+    }
+    for (size_t i = 0; i < pool->count; ++i) {
+        if (pool->formulas[i].gene.length == gene->length &&
+            k_memcmp(pool->formulas[i].gene.digits, gene->digits, gene->length) == 0) {
+            pool->formulas[i].feedback += delta;
+            if (pool->formulas[i].feedback > 1.0) {
+                pool->formulas[i].feedback = 1.0;
+            }
+            if (pool->formulas[i].feedback < -1.0) {
+                pool->formulas[i].feedback = -1.0;
+            }
+            return 0;
+        }
+    }
+    return -1;
+}

--- a/kernel/genome.c
+++ b/kernel/genome.c
@@ -1,0 +1,86 @@
+#include "kolibri/genome.h"
+
+#include "support.h"
+
+typedef struct {
+    uint32_t index;
+    char event_type[KOLIBRI_EVENT_TYPE_SIZE];
+    char payload[KOLIBRI_PAYLOAD_SIZE];
+} GenomeRecord;
+
+int kg_open(KolibriGenome *ctx, uint8_t *storage, size_t capacity) {
+    if (!ctx || !storage || capacity < sizeof(GenomeRecord)) {
+        return -1;
+    }
+    ctx->data = storage;
+    ctx->capacity = capacity;
+    ctx->size = 0U;
+    ctx->next_index = 0U;
+
+    size_t offset = 0U;
+    while (offset + sizeof(GenomeRecord) <= capacity) {
+        const GenomeRecord *record = (const GenomeRecord *)(storage + offset);
+        if (record->event_type[0] == '\0') {
+            break;
+        }
+        ctx->size = offset + sizeof(GenomeRecord);
+        ctx->next_index = record->index + 1U;
+        offset += sizeof(GenomeRecord);
+    }
+    return 0;
+}
+
+void kg_close(KolibriGenome *ctx) {
+    if (!ctx) {
+        return;
+    }
+    ctx->data = NULL;
+    ctx->size = 0U;
+    ctx->capacity = 0U;
+    ctx->next_index = 0U;
+}
+
+int kg_append(KolibriGenome *ctx, const char *event_type, const char *payload, ReasonBlock *out_block) {
+    if (!ctx || !ctx->data || !event_type || !payload) {
+        return -1;
+    }
+    if (ctx->size + sizeof(GenomeRecord) > ctx->capacity) {
+        return -1;
+    }
+    GenomeRecord *record = (GenomeRecord *)(ctx->data + ctx->size);
+    k_memset(record, 0, sizeof(*record));
+    record->index = ctx->next_index++;
+    k_strlcpy(record->event_type, event_type, sizeof(record->event_type));
+    k_strlcpy(record->payload, payload, sizeof(record->payload));
+    ctx->size += sizeof(GenomeRecord);
+
+    if (ctx->size + sizeof(GenomeRecord) <= ctx->capacity) {
+        GenomeRecord *sentinel = (GenomeRecord *)(ctx->data + ctx->size);
+        k_memset(sentinel, 0, sizeof(*sentinel));
+    }
+
+    if (out_block) {
+        out_block->index = record->index;
+        k_strlcpy(out_block->event_type, record->event_type, sizeof(out_block->event_type));
+        k_strlcpy(out_block->payload, record->payload, sizeof(out_block->payload));
+    }
+    return 0;
+}
+
+int kg_replay(const KolibriGenome *ctx, ReasonBlock *out_block, uint32_t index) {
+    if (!ctx || !ctx->data || !out_block) {
+        return -1;
+    }
+    size_t offset = 0U;
+    while (offset + sizeof(GenomeRecord) <= ctx->size) {
+        const GenomeRecord *record = (const GenomeRecord *)(ctx->data + offset);
+        if (record->index == index) {
+            out_block->index = record->index;
+            k_strlcpy(out_block->event_type, record->event_type, sizeof(out_block->event_type));
+            k_strlcpy(out_block->payload, record->payload, sizeof(out_block->payload));
+            return 0;
+        }
+        offset += sizeof(GenomeRecord);
+    }
+    return -1;
+}

--- a/kernel/kolibri/formula.h
+++ b/kernel/kolibri/formula.h
@@ -1,0 +1,39 @@
+#ifndef KOLIBRI_KERNEL_FORMULA_H
+#define KOLIBRI_KERNEL_FORMULA_H
+
+#include "kolibri/random.h"
+
+#include <stddef.h>
+#include <stdint.h>
+
+typedef struct {
+    uint8_t digits[32];
+    size_t length;
+} KolibriGene;
+
+typedef struct {
+    KolibriGene gene;
+    double fitness;
+    double feedback;
+} KolibriFormula;
+
+typedef struct {
+    KolibriFormula formulas[16];
+    size_t count;
+    KolibriRng rng;
+    int inputs[32];
+    int targets[32];
+    size_t examples;
+} KolibriFormulaPool;
+
+void kf_pool_init(KolibriFormulaPool *pool, uint64_t seed);
+void kf_pool_clear_examples(KolibriFormulaPool *pool);
+int kf_pool_add_example(KolibriFormulaPool *pool, int input, int target);
+void kf_pool_tick(KolibriFormulaPool *pool, size_t generations);
+const KolibriFormula *kf_pool_best(const KolibriFormulaPool *pool);
+int kf_formula_apply(const KolibriFormula *formula, int input, int *output);
+size_t kf_formula_digits(const KolibriFormula *formula, uint8_t *out, size_t out_len);
+int kf_formula_describe(const KolibriFormula *formula, char *buffer, size_t buffer_len);
+int kf_pool_feedback(KolibriFormulaPool *pool, const KolibriGene *gene, double delta);
+
+#endif /* KOLIBRI_KERNEL_FORMULA_H */

--- a/kernel/kolibri/genome.h
+++ b/kernel/kolibri/genome.h
@@ -1,0 +1,29 @@
+#ifndef KOLIBRI_KERNEL_GENOME_H
+#define KOLIBRI_KERNEL_GENOME_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#define KOLIBRI_GENOME_CAPACITY 4096U
+#define KOLIBRI_EVENT_TYPE_SIZE 32U
+#define KOLIBRI_PAYLOAD_SIZE 128U
+
+typedef struct {
+    uint32_t index;
+    char event_type[KOLIBRI_EVENT_TYPE_SIZE];
+    char payload[KOLIBRI_PAYLOAD_SIZE];
+} ReasonBlock;
+
+typedef struct {
+    uint8_t *data;
+    size_t size;
+    size_t capacity;
+    uint32_t next_index;
+} KolibriGenome;
+
+int kg_open(KolibriGenome *ctx, uint8_t *storage, size_t capacity);
+void kg_close(KolibriGenome *ctx);
+int kg_append(KolibriGenome *ctx, const char *event_type, const char *payload, ReasonBlock *out_block);
+int kg_replay(const KolibriGenome *ctx, ReasonBlock *out_block, uint32_t index);
+
+#endif /* KOLIBRI_KERNEL_GENOME_H */

--- a/kernel/kolibri/net.h
+++ b/kernel/kolibri/net.h
@@ -1,0 +1,21 @@
+#ifndef KOLIBRI_KERNEL_NET_H
+#define KOLIBRI_KERNEL_NET_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#define KOLIBRI_SLIP_MAX_PAYLOAD 256U
+
+typedef struct {
+    uint16_t local_port;
+    uint16_t remote_port;
+    uint8_t remote_ip[4];
+    uint8_t tx_buffer[KOLIBRI_SLIP_MAX_PAYLOAD + 32U];
+} KolibriSlipUdp;
+
+void kn_slip_udp_init(KolibriSlipUdp *ctx, uint16_t local_port);
+void kn_slip_udp_set_remote(KolibriSlipUdp *ctx, const uint8_t ip[4], uint16_t port);
+void kn_slip_udp_send(KolibriSlipUdp *ctx, const uint8_t *payload, size_t length);
+void kn_slip_udp_send_hello(KolibriSlipUdp *ctx, uint32_t node_id);
+
+#endif /* KOLIBRI_KERNEL_NET_H */

--- a/kernel/kolibri/random.h
+++ b/kernel/kolibri/random.h
@@ -1,0 +1,14 @@
+#ifndef KOLIBRI_KERNEL_RANDOM_H
+#define KOLIBRI_KERNEL_RANDOM_H
+
+#include <stdint.h>
+
+typedef struct {
+    uint64_t state;
+} KolibriRng;
+
+void k_rng_seed(KolibriRng *rng, uint64_t seed);
+uint64_t k_rng_next(KolibriRng *rng);
+double k_rng_next_double(KolibriRng *rng);
+
+#endif /* KOLIBRI_KERNEL_RANDOM_H */

--- a/kernel/net.c
+++ b/kernel/net.c
@@ -1,0 +1,146 @@
+#include "kolibri/net.h"
+
+#include "serial.h"
+#include "support.h"
+
+#define SLIP_END 0xC0U
+#define SLIP_ESC 0xDBU
+#define SLIP_ESC_END 0xDCU
+#define SLIP_ESC_ESC 0xDDU
+
+static const uint8_t LOCAL_IP[4] = {192U, 168U, 0U, 2U};
+
+static void slip_send_byte(uint8_t byte) {
+    if (byte == SLIP_END) {
+        serial_write_char((char)SLIP_ESC);
+        serial_write_char((char)SLIP_ESC_END);
+    } else if (byte == SLIP_ESC) {
+        serial_write_char((char)SLIP_ESC);
+        serial_write_char((char)SLIP_ESC_ESC);
+    } else {
+        serial_write_char((char)byte);
+    }
+}
+
+static uint16_t ip_checksum(const uint8_t *data, size_t length) {
+    uint32_t sum = 0U;
+    for (size_t i = 0; i + 1 < length; i += 2) {
+        uint16_t word = (uint16_t)((data[i] << 8) | data[i + 1]);
+        sum += word;
+    }
+    if (length & 1U) {
+        sum += (uint16_t)(data[length - 1] << 8);
+    }
+    while (sum >> 16U) {
+        sum = (sum & 0xFFFFU) + (sum >> 16U);
+    }
+    return (uint16_t)(~sum);
+}
+
+static size_t build_ipv4_udp(const KolibriSlipUdp *ctx, const uint8_t *payload, size_t length, uint8_t *out) {
+    const size_t ip_header = 20U;
+    const size_t udp_header = 8U;
+    size_t total = ip_header + udp_header + length;
+    if (total > KOLIBRI_SLIP_MAX_PAYLOAD) {
+        total = KOLIBRI_SLIP_MAX_PAYLOAD;
+    }
+    size_t payload_len = total - ip_header - udp_header;
+    k_memset(out, 0, total);
+    out[0] = 0x45U;
+    out[1] = 0x00U;
+    uint16_t total_len = (uint16_t)total;
+    out[2] = (uint8_t)(total_len >> 8);
+    out[3] = (uint8_t)(total_len & 0xFFU);
+    out[8] = 64U;
+    out[9] = 17U;
+    k_memcpy(&out[12], LOCAL_IP, 4U);
+    k_memcpy(&out[16], ctx->remote_ip, 4U);
+    uint16_t checksum = ip_checksum(out, ip_header);
+    out[10] = (uint8_t)(checksum >> 8);
+    out[11] = (uint8_t)(checksum & 0xFFU);
+
+    uint16_t src_port = ctx->local_port;
+    uint16_t dst_port = ctx->remote_port;
+    out[ip_header + 0] = (uint8_t)(src_port >> 8);
+    out[ip_header + 1] = (uint8_t)(src_port & 0xFFU);
+    out[ip_header + 2] = (uint8_t)(dst_port >> 8);
+    out[ip_header + 3] = (uint8_t)(dst_port & 0xFFU);
+    uint16_t udp_len = (uint16_t)(udp_header + payload_len);
+    out[ip_header + 4] = (uint8_t)(udp_len >> 8);
+    out[ip_header + 5] = (uint8_t)(udp_len & 0xFFU);
+    out[ip_header + 6] = 0U;
+    out[ip_header + 7] = 0U;
+
+    for (size_t i = 0; i < payload_len; ++i) {
+        out[ip_header + udp_header + i] = payload[i];
+    }
+    return total;
+}
+
+void kn_slip_udp_init(KolibriSlipUdp *ctx, uint16_t local_port) {
+    if (!ctx) {
+        return;
+    }
+    k_memset(ctx, 0, sizeof(*ctx));
+    ctx->local_port = local_port;
+    ctx->remote_port = local_port;
+    ctx->remote_ip[0] = 192U;
+    ctx->remote_ip[1] = 168U;
+    ctx->remote_ip[2] = 0U;
+    ctx->remote_ip[3] = 1U;
+}
+
+void kn_slip_udp_set_remote(KolibriSlipUdp *ctx, const uint8_t ip[4], uint16_t port) {
+    if (!ctx || !ip) {
+        return;
+    }
+    k_memcpy(ctx->remote_ip, ip, 4U);
+    ctx->remote_port = port;
+}
+
+void kn_slip_udp_send(KolibriSlipUdp *ctx, const uint8_t *payload, size_t length) {
+    if (!ctx || !payload || length == 0U) {
+        return;
+    }
+    size_t packet_len = build_ipv4_udp(ctx, payload, length, ctx->tx_buffer);
+    serial_write_char((char)SLIP_END);
+    for (size_t i = 0; i < packet_len; ++i) {
+        slip_send_byte(ctx->tx_buffer[i]);
+    }
+    serial_write_char((char)SLIP_END);
+}
+
+static size_t u32_to_dec(uint32_t value, char *buffer, size_t buffer_len) {
+    if (!buffer || buffer_len == 0U) {
+        return 0U;
+    }
+    char temp[16];
+    size_t index = 0U;
+    if (value == 0U) {
+        temp[index++] = '0';
+    } else {
+        while (value > 0U && index < sizeof(temp)) {
+            temp[index++] = (char)('0' + (value % 10U));
+            value /= 10U;
+        }
+    }
+    size_t written = 0U;
+    while (written < index && written + 1U < buffer_len) {
+        buffer[written] = temp[index - written - 1U];
+        ++written;
+    }
+    if (written < buffer_len) {
+        buffer[written++] = '\0';
+    }
+    return written;
+}
+
+void kn_slip_udp_send_hello(KolibriSlipUdp *ctx, uint32_t node_id) {
+    if (!ctx) {
+        return;
+    }
+    char message[64];
+    k_strlcpy(message, "HELLO:", sizeof(message));
+    u32_to_dec(node_id, message + 6, sizeof(message) - 6U);
+    kn_slip_udp_send(ctx, (const uint8_t *)message, k_strlen(message));
+}

--- a/kernel/ramdisk.c
+++ b/kernel/ramdisk.c
@@ -1,0 +1,53 @@
+#include "ramdisk.h"
+
+#include "support.h"
+
+#define RAMDISK_MAGIC 0x4B4F474EU /* 'KOGN' */
+
+static uint8_t ramdisk_buffer[KOLIBRI_RAMDISK_SIZE];
+static size_t ramdisk_used = 0U;
+
+void ramdisk_init(void) {
+    uint32_t stored_magic = 0U;
+    k_memcpy(&stored_magic, ramdisk_buffer, sizeof(stored_magic));
+    if (stored_magic != RAMDISK_MAGIC) {
+        k_memset(ramdisk_buffer, 0, sizeof(ramdisk_buffer));
+        stored_magic = RAMDISK_MAGIC;
+        k_memcpy(ramdisk_buffer, &stored_magic, sizeof(stored_magic));
+        ramdisk_used = 0U;
+    } else {
+        k_memcpy(&ramdisk_used, ramdisk_buffer + sizeof(stored_magic), sizeof(ramdisk_used));
+        if (ramdisk_used > KOLIBRI_RAMDISK_SIZE - sizeof(stored_magic) - sizeof(ramdisk_used)) {
+            ramdisk_used = 0U;
+        }
+    }
+    size_t capacity = ramdisk_capacity();
+    if (ramdisk_used < capacity) {
+        k_memset(ramdisk_data() + ramdisk_used, 0, capacity - ramdisk_used);
+    }
+}
+
+uint8_t *ramdisk_data(void) {
+    return ramdisk_buffer + sizeof(uint32_t) + sizeof(size_t);
+}
+
+size_t ramdisk_capacity(void) {
+    return KOLIBRI_RAMDISK_SIZE - sizeof(uint32_t) - sizeof(size_t);
+}
+
+size_t ramdisk_size(void) {
+    return ramdisk_used;
+}
+
+void ramdisk_commit(size_t used_bytes) {
+    size_t capacity = ramdisk_capacity();
+    if (used_bytes > capacity) {
+        used_bytes = capacity;
+    }
+    ramdisk_used = used_bytes;
+    k_memcpy(ramdisk_buffer, &(uint32_t){RAMDISK_MAGIC}, sizeof(uint32_t));
+    k_memcpy(ramdisk_buffer + sizeof(uint32_t), &ramdisk_used, sizeof(ramdisk_used));
+    if (ramdisk_used < capacity) {
+        k_memset(ramdisk_data() + ramdisk_used, 0, capacity - ramdisk_used);
+    }
+}

--- a/kernel/ramdisk.h
+++ b/kernel/ramdisk.h
@@ -1,0 +1,15 @@
+#ifndef KOLIBRI_KERNEL_RAMDISK_H
+#define KOLIBRI_KERNEL_RAMDISK_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#define KOLIBRI_RAMDISK_SIZE 4096U
+
+void ramdisk_init(void);
+uint8_t *ramdisk_data(void);
+size_t ramdisk_capacity(void);
+size_t ramdisk_size(void);
+void ramdisk_commit(size_t used_bytes);
+
+#endif /* KOLIBRI_KERNEL_RAMDISK_H */

--- a/kernel/random.c
+++ b/kernel/random.c
@@ -1,0 +1,29 @@
+#include "kolibri/random.h"
+
+#include <stdint.h>
+
+#define K_RNG_MULTIPLIER 6364136223846793005ULL
+#define K_RNG_INCREMENT 1442695040888963407ULL
+
+void k_rng_seed(KolibriRng *rng, uint64_t seed) {
+    if (!rng) {
+        return;
+    }
+    rng->state = seed + K_RNG_INCREMENT;
+    (void)k_rng_next(rng);
+}
+
+uint64_t k_rng_next(KolibriRng *rng) {
+    if (!rng) {
+        return 0ULL;
+    }
+    rng->state = rng->state * K_RNG_MULTIPLIER + K_RNG_INCREMENT;
+    uint64_t xorshifted = ((rng->state >> 18U) ^ rng->state) >> 27U;
+    uint64_t rot = rng->state >> 59U;
+    return (xorshifted >> rot) | (xorshifted << ((-(int32_t)rot) & 31));
+}
+
+double k_rng_next_double(KolibriRng *rng) {
+    const uint64_t value = k_rng_next(rng);
+    return (value >> 11) * (1.0 / 9007199254740992.0);
+}

--- a/kernel/serial.c
+++ b/kernel/serial.c
@@ -1,0 +1,68 @@
+#include "serial.h"
+
+static inline void io_out8(uint16_t port, uint8_t value) {
+    __asm__ __volatile__("outb %0, %1" : : "a"(value), "Nd"(port));
+}
+
+static inline uint8_t io_in8(uint16_t port) {
+    uint8_t value;
+    __asm__ __volatile__("inb %1, %0" : "=a"(value) : "Nd"(port));
+    return value;
+}
+
+#define COM1_BASE 0x3F8U
+
+void serial_init(uint32_t baud_divisor) {
+    io_out8(COM1_BASE + 1U, 0x00U);
+    io_out8(COM1_BASE + 3U, 0x80U);
+    io_out8(COM1_BASE + 0U, (uint8_t)(baud_divisor & 0xFFU));
+    io_out8(COM1_BASE + 1U, (uint8_t)((baud_divisor >> 8U) & 0xFFU));
+    io_out8(COM1_BASE + 3U, 0x03U);
+    io_out8(COM1_BASE + 2U, 0xC7U);
+    io_out8(COM1_BASE + 4U, 0x0BU);
+}
+
+static void serial_wait_tx(void) {
+    while ((io_in8(COM1_BASE + 5U) & 0x20U) == 0U) {
+    }
+}
+
+void serial_write_char(char c) {
+    if (c == '\n') {
+        serial_write_char('\r');
+    }
+    serial_wait_tx();
+    io_out8(COM1_BASE, (uint8_t)c);
+}
+
+void serial_write_string(const char *str) {
+    if (!str) {
+        return;
+    }
+    while (*str) {
+        serial_write_char(*str++);
+    }
+}
+
+static char to_hex(uint8_t nibble) {
+    nibble &= 0x0FU;
+    return (char)((nibble < 10U) ? ('0' + nibble) : ('A' + (nibble - 10U)));
+}
+
+void serial_write_hex32(uint32_t value) {
+    serial_write_string("0x");
+    for (int shift = 28; shift >= 0; shift -= 4) {
+        serial_write_char(to_hex((uint8_t)((value >> shift) & 0x0FU)));
+    }
+}
+
+int serial_read_char(char *out) {
+    if (!out) {
+        return -1;
+    }
+    if ((io_in8(COM1_BASE + 5U) & 0x01U) == 0U) {
+        return 1;
+    }
+    *out = (char)io_in8(COM1_BASE);
+    return 0;
+}

--- a/kernel/serial.h
+++ b/kernel/serial.h
@@ -1,0 +1,13 @@
+#ifndef KOLIBRI_KERNEL_SERIAL_H
+#define KOLIBRI_KERNEL_SERIAL_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+void serial_init(uint32_t baud_divisor);
+void serial_write_char(char c);
+void serial_write_string(const char *str);
+void serial_write_hex32(uint32_t value);
+int serial_read_char(char *out);
+
+#endif /* KOLIBRI_KERNEL_SERIAL_H */

--- a/kernel/support.c
+++ b/kernel/support.c
@@ -1,0 +1,82 @@
+#include "support.h"
+
+#include <stdint.h>
+
+void *k_memcpy(void *dest, const void *src, size_t n) {
+    uint8_t *d = (uint8_t *)dest;
+    const uint8_t *s = (const uint8_t *)src;
+    for (size_t i = 0; i < n; ++i) {
+        d[i] = s[i];
+    }
+    return dest;
+}
+
+void *k_memset(void *dest, int value, size_t n) {
+    uint8_t *d = (uint8_t *)dest;
+    uint8_t byte = (uint8_t)value;
+    for (size_t i = 0; i < n; ++i) {
+        d[i] = byte;
+    }
+    return dest;
+}
+
+int k_memcmp(const void *lhs, const void *rhs, size_t n) {
+    const uint8_t *a = (const uint8_t *)lhs;
+    const uint8_t *b = (const uint8_t *)rhs;
+    for (size_t i = 0; i < n; ++i) {
+        if (a[i] != b[i]) {
+            return (int)a[i] - (int)b[i];
+        }
+    }
+    return 0;
+}
+
+size_t k_strlen(const char *str) {
+    size_t len = 0U;
+    if (!str) {
+        return 0U;
+    }
+    while (str[len] != '\0') {
+        ++len;
+    }
+    return len;
+}
+
+char *k_strncpy(char *dest, const char *src, size_t n) {
+    if (!dest || !src || n == 0U) {
+        return dest;
+    }
+    size_t i = 0U;
+    for (; i < n - 1U && src[i] != '\0'; ++i) {
+        dest[i] = src[i];
+    }
+    dest[i] = '\0';
+    return dest;
+}
+
+size_t k_strlcpy(char *dest, const char *src, size_t n) {
+    size_t src_len = k_strlen(src);
+    if (!dest || n == 0U) {
+        return src_len;
+    }
+    size_t copy_len = src_len;
+    if (copy_len >= n) {
+        copy_len = n - 1U;
+    }
+    for (size_t i = 0; i < copy_len; ++i) {
+        dest[i] = src[i];
+    }
+    dest[copy_len] = '\0';
+    return src_len;
+}
+
+int k_strcmp(const char *lhs, const char *rhs) {
+    size_t i = 0U;
+    while (lhs[i] != '\0' && rhs[i] != '\0') {
+        if (lhs[i] != rhs[i]) {
+            return (int)((unsigned char)lhs[i]) - (int)((unsigned char)rhs[i]);
+        }
+        ++i;
+    }
+    return (int)((unsigned char)lhs[i]) - (int)((unsigned char)rhs[i]);
+}

--- a/kernel/support.h
+++ b/kernel/support.h
@@ -1,0 +1,26 @@
+#ifndef KOLIBRI_KERNEL_SUPPORT_H
+#define KOLIBRI_KERNEL_SUPPORT_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+void *k_memcpy(void *dest, const void *src, size_t n);
+void *k_memset(void *dest, int value, size_t n);
+int k_memcmp(const void *lhs, const void *rhs, size_t n);
+size_t k_strlen(const char *str);
+char *k_strncpy(char *dest, const char *src, size_t n);
+size_t k_strlcpy(char *dest, const char *src, size_t n);
+int k_strcmp(const char *lhs, const char *rhs);
+
+static inline uint16_t k_htons(uint16_t value) {
+    return (uint16_t)((value << 8) | (value >> 8));
+}
+
+static inline uint32_t k_htonl(uint32_t value) {
+    return ((value & 0x000000FFU) << 24) |
+           ((value & 0x0000FF00U) << 8) |
+           ((value & 0x00FF0000U) >> 8) |
+           ((value & 0xFF000000U) >> 24);
+}
+
+#endif /* KOLIBRI_KERNEL_SUPPORT_H */


### PR DESCRIPTION
## Summary
- add a NASM boot sector and extend the release script to produce a kolibri.img bootable image
- expand the freestanding kernel with support, RNG, formula, RAM-disk genome storage, SLIP/UDP networking, and serial telemetry
- document the new build pipeline, RAM-disk usage, and serial/SLIP message formats in kolibri_os.md

## Testing
- not run (toolchain components such as grub-mkrescue are unavailable in the environment)

------
https://chatgpt.com/codex/tasks/task_e_68d943a3ea2483239a21204cfd124d0f