### PR TITLE
Ensure sendMessage updates when bridge readiness changes

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -93,7 +93,7 @@ const App = () => {
     } finally {
       setIsProcessing(false);
     }
-  }, [draft, isProcessing, mode]);
+  }, [bridgeReady, draft, isProcessing, mode]);
 
   const content = useMemo(() => {
     if (!messages.length) {


### PR DESCRIPTION
## Summary
- include `bridgeReady` in the `sendMessage` callback dependencies so it reflects current bridge state

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68da4cebda188323aae3c505346d3cfc