### PR TITLE
Fix ISO build script for backend headers and 32-bit toolchains

### DIFF
--- a/kernel/formula.c
+++ b/kernel/formula.c
@@ -5,7 +5,8 @@
 #define KOLIBRI_FORMULA_CAPACITY (sizeof(((KolibriFormulaPool *)0)->formulas) / sizeof(KolibriFormula))
 
 static uint8_t random_digit(KolibriFormulaPool *pool) {
-    return (uint8_t)(k_rng_next(&pool->rng) % 10ULL);
+    uint32_t value = (uint32_t)k_rng_next(&pool->rng);
+    return (uint8_t)(value % 10U);
 }
 
 static void gene_randomize(KolibriFormulaPool *pool, KolibriGene *gene) {
@@ -59,7 +60,8 @@ static void mutate_gene(KolibriFormulaPool *pool, KolibriGene *gene) {
     if (!gene) {
         return;
     }
-    size_t index = (size_t)(k_rng_next(&pool->rng) % gene->length);
+    uint32_t value = (uint32_t)k_rng_next(&pool->rng);
+    size_t index = (size_t)(value % (gene->length ? gene->length : 1U));
     gene->digits[index] = random_digit(pool);
 }
 

--- a/kernel/main.c
+++ b/kernel/main.c
@@ -373,7 +373,7 @@ static void preobrazovat_bajt_v_hex(uint8_t znachenie, char *vyhod) {
 /* Обработчик аппаратного таймера. */
 void obrabotat_tajmer(void) {
     ++schetchik_tickov;
-    if (schetchik_tickov % 100ULL == 0ULL) {
+    if (((uint32_t)schetchik_tickov % 100U) == 0U) {
         vga_pechat_stroku("[TICK]\n");
     }
     poslati_eoi(0U);


### PR DESCRIPTION
## Summary
- allow the kernel build to find kolibri headers by adding the backend include path
- avoid requiring 32-bit system libraries when probing the compiler by compiling to an object file
- eliminate 64-bit modulus operations in the kernel RNG usage so the build does not rely on libgcc helper routines

## Testing
- ./scripts/build_iso.sh --kernel-only

------
https://chatgpt.com/codex/tasks/task_e_68da50919f08832381a1190f857ff604