### PR TITLE
Specify requirements file for setup-python caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
         with:
           python-version: '3.11'
           cache: pip
+          cache-dependency-path: requirements.txt
       - name: Установка инструментов
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
## Summary
- point the setup-python step to the repository's requirements.txt so the pip cache can be created

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68da50ec7fd08323995bbe7712d8dff1