### PR TITLE
Improve soak state handling in KolibriSim

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
         with:
           python-version: '3.11'
           cache: pip
+          cache-dependency-path: requirements.txt
       - name: Установка инструментов
         run: |
           python -m pip install --upgrade pip

--- a/core/kolibri_sim.py
+++ b/core/kolibri_sim.py
@@ -462,17 +462,17 @@ def obnovit_soak_state(path: Path, sim: KolibriSim, minuti: int) -> SoakState:
     tekuschee: SoakState = cast(SoakState, tekuschee_raw)
     itogi = sim.zapustit_soak(minuti)
 
-    metrics: List[MetricEntry]
-    metrics_obj = tekuschee_raw.get("metrics")
+    metrics_obj = tekuschee.get("metrics")
     if isinstance(metrics_obj, list):
-        metrics: List[MetricEntry] = cast(List[MetricEntry], metrics_obj)
+        metrics = cast(List[MetricEntry], metrics_obj)
     else:
         metrics = []
         tekuschee["metrics"] = metrics
     metrics.extend(itogi["metrics"])
 
-    events_obj = tekuschee_raw.get("events")
-    events_prev = events_obj if isinstance(events_obj, int) else 0
+    events_prev = tekuschee.get("events")
+    if not isinstance(events_prev, int):
+        events_prev = 0
     tekuschee["events"] = events_prev + itogi["events"]
     sohranit_sostoyanie(path, tekuschee)
     return tekuschee


### PR DESCRIPTION
## Summary
- reuse the typed soak state mapping when merging persisted metrics
- guard the stored event counter so missing or invalid values default to zero

## Testing
- pyright
- ruff check .
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68da50ec7fd08323995bbe7712d8dff1