### PR TITLE
Add reset functionality to Kolibri bridge

### DIFF
--- a/frontend/src/core/kolibri-bridge.ts
+++ b/frontend/src/core/kolibri-bridge.ts
@@ -9,6 +9,7 @@
 export interface KolibriBridge {
   readonly ready: Promise<void>;
   ask(prompt: string, mode?: string): Promise<string>;
+  reset(): Promise<void>;
 }
 
 interface KolibriWasmExports extends WebAssembly.Exports {
@@ -145,6 +146,18 @@ class KolibriWasmBridge implements KolibriBridge {
     } finally {
       exports._free(programPtr);
       exports._free(outputPtr);
+    }
+  }
+
+  async reset(): Promise<void> {
+    await this.ready;
+    if (!this.exports) {
+      throw new Error("Kolibri WASM мост не готов");
+    }
+
+    const result = this.exports._kolibri_bridge_reset();
+    if (result !== 0) {
+      throw new Error(`Не удалось сбросить KolibriScript (код ${result})`);
     }
   }
 


### PR DESCRIPTION
## Summary
- extend the Kolibri bridge with a reset method that calls the WASM binding and surfaces errors
- update the application reset handler to invoke the bridge reset before clearing state and surface failures to the user

## Testing
- npm run build *(fails: missing /workspace/os/build/wasm/kolibri.wasm; run scripts/build_wasm.sh before building)*

------
https://chatgpt.com/codex/tasks/task_e_68da775f19c48323ad9bdf7390898aa7