### PR TITLE
Add auto-scroll behavior to chat view

### DIFF
--- a/frontend/src/components/ChatView.tsx
+++ b/frontend/src/components/ChatView.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from "react";
 import type { ChatMessage } from "../types/chat";
 import ChatMessageView from "./ChatMessage";
 
@@ -6,25 +7,39 @@ interface ChatViewProps {
   isLoading: boolean;
 }
 
-const ChatView = ({ messages, isLoading }: ChatViewProps) => (
-  <section className="flex h-full flex-col rounded-3xl bg-white/70 p-8 shadow-card">
-    <div className="flex-1 space-y-6 overflow-y-auto pr-2">
-      {messages.map((message) => (
-        <ChatMessageView key={message.id} message={message} />
-      ))}
-      {isLoading && (
-        <div className="flex items-center gap-3 text-sm text-text-light">
-          <span className="h-2 w-2 animate-pulse rounded-full bg-primary" />
-          Колибри формирует ответ...
-        </div>
-      )}
-      {!messages.length && !isLoading && (
-        <div className="rounded-2xl bg-background-light/60 p-6 text-sm text-text-light">
-          Отправь сообщение, чтобы начать диалог с Колибри.
-        </div>
-      )}
-    </div>
-  </section>
-);
+const ChatView = ({ messages, isLoading }: ChatViewProps) => {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const container = containerRef.current;
+
+    if (!container) {
+      return;
+    }
+
+    container.scrollTop = container.scrollHeight;
+  }, [messages, isLoading]);
+
+  return (
+    <section className="flex h-full flex-col rounded-3xl bg-white/70 p-8 shadow-card">
+      <div className="flex-1 space-y-6 overflow-y-auto pr-2" ref={containerRef}>
+        {messages.map((message) => (
+          <ChatMessageView key={message.id} message={message} />
+        ))}
+        {isLoading && (
+          <div className="flex items-center gap-3 text-sm text-text-light">
+            <span className="h-2 w-2 animate-pulse rounded-full bg-primary" />
+            Колибри формирует ответ...
+          </div>
+        )}
+        {!messages.length && !isLoading && (
+          <div className="rounded-2xl bg-background-light/60 p-6 text-sm text-text-light">
+            Отправь сообщение, чтобы начать диалог с Колибри.
+          </div>
+        )}
+      </div>
+    </section>
+  );
+};
 
 export default ChatView;


### PR DESCRIPTION
## Summary
- add a ref to the chat messages container and automatically scroll when messages update
- ensure the loading indicator is visible by scrolling during loading state changes

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68da7768f68c8323a35fe1e6e948607a