### PR TITLE
Fix Makefile tab for wasm target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,5 +25,5 @@ iso: kernel
 check: test iso wasm
 
 wasm: build
-        cmake --build build --target kolibri_wasm
+	cmake --build build --target kolibri_wasm
 


### PR DESCRIPTION
## Summary
- replace the space-indented command in the `wasm` rule with a Make-compatible tab so the target builds correctly

## Testing
- make -n wasm

------
https://chatgpt.com/codex/tasks/task_e_68db8db5e5688323816e4ec942405a5f