### PR TITLE
Inline WASI smoke test module

### DIFF
--- a/frontend/src/core/wasi.ts
+++ b/frontend/src/core/wasi.ts
@@ -1,0 +1,157 @@
+const WASI_ERRNO_SUCCESS = 0;
+const WASI_ERRNO_BADF = 8;
+const WASI_ERRNO_INVAL = 28;
+const WASI_FILETYPE_CHARACTER_DEVICE = 2;
+const FDSTAT_SIZE = 24;
+
+interface WasiContext {
+  imports: Record<string, WebAssembly.ImportValue>;
+  setMemory(memory: WebAssembly.Memory): void;
+}
+
+const textDecoder = new TextDecoder("utf-8");
+
+function getRandomBytes(buffer: Uint8Array): void {
+  if (typeof crypto !== "undefined" && "getRandomValues" in crypto) {
+    crypto.getRandomValues(buffer);
+    return;
+  }
+  for (let index = 0; index < buffer.length; index += 1) {
+    buffer[index] = Math.floor(Math.random() * 256);
+  }
+}
+
+export function createWasiContext(onStdout?: (text: string) => void): WasiContext {
+  let memory: WebAssembly.Memory | null = null;
+  let memoryView: DataView | null = null;
+
+  const ensureView = (): DataView => {
+    if (!memoryView) {
+      throw new Error("WASI memory не инициализирована");
+    }
+    return memoryView;
+  };
+
+  const readBytes = (ptr: number, length: number): Uint8Array => {
+    if (!memory) {
+      throw new Error("WASI memory не инициализирована");
+    }
+    return new Uint8Array(memory.buffer, ptr, length);
+  };
+
+  const writeU32 = (ptr: number, value: number): void => {
+    if (!memoryView) {
+      return;
+    }
+    memoryView.setUint32(ptr, value >>> 0, true);
+  };
+
+  const writeU64 = (ptr: number, value: bigint): void => {
+    if (!memoryView) {
+      return;
+    }
+    memoryView.setBigUint64(ptr, value, true);
+  };
+
+  const imports: Record<string, WebAssembly.ImportValue> = {
+    fd_close: (fd: number): number => {
+      void fd;
+      return WASI_ERRNO_SUCCESS;
+    },
+    fd_fdstat_get: (fd: number, statPtr: number): number => {
+      if (fd < 0) {
+        return WASI_ERRNO_BADF;
+      }
+      if (!memory || !memoryView) {
+        return WASI_ERRNO_INVAL;
+      }
+      const view = memoryView;
+      const buffer = new Uint8Array(memory.buffer, statPtr, FDSTAT_SIZE);
+      buffer.fill(0);
+      view.setUint8(statPtr, WASI_FILETYPE_CHARACTER_DEVICE);
+      view.setUint16(statPtr + 2, 0, true);
+      view.setBigUint64(statPtr + 8, 0n, true);
+      view.setBigUint64(statPtr + 16, 0n, true);
+      return WASI_ERRNO_SUCCESS;
+    },
+    fd_seek: (
+      fd: number,
+      offset: number | bigint,
+      whence: number,
+      resultPtr: number,
+    ): number => {
+      void fd;
+      void offset;
+      void whence;
+      writeU64(resultPtr, 0n);
+      return WASI_ERRNO_SUCCESS;
+    },
+    fd_write: (fd: number, iovsPtr: number, iovsLen: number, nwrittenPtr: number): number => {
+      if (!memory || !memoryView) {
+        return WASI_ERRNO_INVAL;
+      }
+      const view = ensureView();
+      let bytesWritten = 0;
+      let aggregated = "";
+      for (let index = 0; index < iovsLen; index += 1) {
+        const ptr = view.getUint32(iovsPtr + index * 8, true);
+        const len = view.getUint32(iovsPtr + index * 8 + 4, true);
+        if (len === 0) {
+          continue;
+        }
+        bytesWritten += len;
+        if (fd === 1 || fd === 2) {
+          const chunk = readBytes(ptr, len);
+          aggregated += textDecoder.decode(chunk);
+        }
+      }
+      writeU32(nwrittenPtr, bytesWritten);
+      if (aggregated && onStdout) {
+        onStdout(aggregated);
+      }
+      return WASI_ERRNO_SUCCESS;
+    },
+    environ_sizes_get: (countPtr: number, sizePtr: number): number => {
+      writeU32(countPtr, 0);
+      writeU32(sizePtr, 0);
+      return WASI_ERRNO_SUCCESS;
+    },
+    environ_get: (): number => WASI_ERRNO_SUCCESS,
+    args_sizes_get: (countPtr: number, sizePtr: number): number => {
+      writeU32(countPtr, 0);
+      writeU32(sizePtr, 0);
+      return WASI_ERRNO_SUCCESS;
+    },
+    args_get: (): number => WASI_ERRNO_SUCCESS,
+    clock_time_get: (
+      clockId: number,
+      precision: number | bigint,
+      timePtr: number,
+    ): number => {
+      void clockId;
+      void precision;
+      const now = BigInt(Date.now()) * 1_000_000n;
+      writeU64(timePtr, now);
+      return WASI_ERRNO_SUCCESS;
+    },
+    random_get: (ptr: number, len: number): number => {
+      if (!memory) {
+        return WASI_ERRNO_INVAL;
+      }
+      const buffer = new Uint8Array(memory.buffer, ptr, len);
+      getRandomBytes(buffer);
+      return WASI_ERRNO_SUCCESS;
+    },
+    proc_exit: (code: number): number => {
+      throw new Error(`WASM завершил выполнение с кодом ${code}`);
+    },
+  };
+
+  return {
+    imports,
+    setMemory(newMemory: WebAssembly.Memory): void {
+      memory = newMemory;
+      memoryView = new DataView(newMemory.buffer);
+    },
+  };
+}

--- a/tests/wasi_smoke.ts
+++ b/tests/wasi_smoke.ts
@@ -1,0 +1,78 @@
+import { createWasiContext } from "../frontend/src/core/wasi";
+
+async function run(): Promise<void> {
+  const bytes = Uint8Array.from([
+    0x00,
+    0x61,
+    0x73,
+    0x6d,
+    0x01,
+    0x00,
+    0x00,
+    0x00,
+    0x05,
+    0x03,
+    0x01,
+    0x00,
+    0x01,
+    0x07,
+    0x0a,
+    0x01,
+    0x06,
+    0x6d,
+    0x65,
+    0x6d,
+    0x6f,
+    0x72,
+    0x79,
+    0x02,
+    0x00,
+  ]);
+
+  const stdout: string[] = [];
+  const wasi = createWasiContext((text) => stdout.push(text));
+  const wasiImports = wasi.imports as Record<string, (fd: number, statPtr: number) => number>;
+  const fdFdstatGet = wasiImports.fd_fdstat_get as (fd: number, statPtr: number) => number;
+
+  const errnoBefore = fdFdstatGet(0, 0);
+  if (errnoBefore !== 28) {
+    throw new Error(`fd_fdstat_get before memory init should return 28, got ${errnoBefore}`);
+  }
+
+  const importObject: WebAssembly.Imports = {
+    wasi_snapshot_preview1: wasi.imports,
+  };
+
+  const { instance } = await WebAssembly.instantiate(bytes, importObject);
+  const exports = instance.exports as { memory: WebAssembly.Memory };
+  wasi.setMemory(exports.memory);
+
+  const targetPtr = 128;
+  const errnoAfter = fdFdstatGet(0, targetPtr);
+  if (errnoAfter !== 0) {
+    throw new Error(`fd_fdstat_get after memory init should succeed, got ${errnoAfter}`);
+  }
+
+  const view = new DataView(exports.memory.buffer);
+  const fileType = view.getUint8(targetPtr);
+  if (fileType !== 2) {
+    throw new Error(`fd_fdstat_get should write filetype=2, got ${fileType}`);
+  }
+
+  for (let offset = 1; offset < 24; offset += 1) {
+    if (view.getUint8(targetPtr + offset) !== 0) {
+      throw new Error(`fd_fdstat_get should zero fdstat, byte ${offset} was non-zero`);
+    }
+  }
+
+  if (stdout.length !== 0) {
+    throw new Error(`wasi stdout should remain empty during smoke test`);
+  }
+
+  console.log("WASI smoke test passed: fd_fdstat_get handles missing memory and instantiation succeeded.");
+}
+
+run().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- replace the wasm fixture file with an inline byte array so the smoke test no longer depends on a binary asset
- keep the smoke test logic intact while using the embedded module bytes

## Testing
- npx --yes tsx tests/wasi_smoke.ts

------
https://chatgpt.com/codex/tasks/task_e_68dbcb56272c83239f491a8166ef15bd