### PR TITLE
Add feedback collection UI and backend service

### DIFF
--- a/backend/feedback_service/__init__.py
+++ b/backend/feedback_service/__init__.py
@@ -1,0 +1,5 @@
+"""Kolibri feedback service package."""
+
+from .main import app
+
+__all__ = ["app"]

--- a/backend/feedback_service/database.py
+++ b/backend/feedback_service/database.py
@@ -1,0 +1,227 @@
+"""Database integration helpers for persisting feedback."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from typing import AsyncIterator, Optional, Protocol
+from urllib.parse import urlparse
+from uuid import uuid4
+
+import asyncpg
+import clickhouse_connect
+
+from .schemas import FeedbackPayload, FeedbackRecord
+
+
+class FeedbackStorageError(RuntimeError):
+    """Raised when feedback persistence fails."""
+
+
+class FeedbackStorage(Protocol):
+    """Protocol describing the feedback persistence interface."""
+
+    async def save_feedback(self, payload: FeedbackPayload) -> FeedbackRecord:
+        """Persist the feedback payload and return the stored record."""
+
+    async def close(self) -> None:
+        """Release all resources allocated by the storage implementation."""
+
+
+class PostgresFeedbackStorage:
+    """Persist feedback in a PostgreSQL database using asyncpg."""
+
+    def __init__(self, dsn: str) -> None:
+        self._dsn = dsn
+        self._pool: Optional[asyncpg.Pool] = None
+        self._lock = asyncio.Lock()
+
+    async def _ensure_pool(self) -> asyncpg.Pool:
+        if self._pool is None:
+            async with self._lock:
+                if self._pool is None:
+                    try:
+                        self._pool = await asyncpg.create_pool(self._dsn)
+                    except Exception as exc:  # pragma: no cover - network errors
+                        raise FeedbackStorageError("Не удалось подключиться к PostgreSQL.") from exc
+        assert self._pool is not None
+        return self._pool
+
+    async def save_feedback(self, payload: FeedbackPayload) -> FeedbackRecord:
+        pool = await self._ensure_pool()
+        record_id = uuid4()
+        record = FeedbackRecord.create(record_id=record_id, payload=payload)
+
+        try:
+            async with pool.acquire() as connection:
+                await connection.execute(
+                    """
+                    INSERT INTO feedback (
+                        id,
+                        conversation_id,
+                        message_id,
+                        rating,
+                        assistant_message,
+                        user_message,
+                        comment,
+                        mode,
+                        created_at
+                    )
+                    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+                    """,
+                    record.id,
+                    record.conversation_id,
+                    record.message_id,
+                    record.rating.value,
+                    record.assistant_message,
+                    record.user_message,
+                    record.comment,
+                    record.mode,
+                    record.created_at,
+                )
+        except Exception as exc:  # pragma: no cover - network errors
+            raise FeedbackStorageError("Не удалось сохранить отзыв в PostgreSQL.") from exc
+
+        return record
+
+    async def close(self) -> None:
+        if self._pool is not None:
+            await self._pool.close()
+            self._pool = None
+
+
+class ClickHouseFeedbackStorage:
+    """Persist feedback in ClickHouse using clickhouse-connect."""
+
+    def __init__(self, dsn: str) -> None:
+        self._dsn = dsn
+        self._client: Optional[clickhouse_connect.driver.Client] = None
+        self._lock = asyncio.Lock()
+
+    def _client_kwargs(self) -> dict[str, object]:
+        parsed = urlparse(self._dsn)
+        database = parsed.path.lstrip("/") or "default"
+        port = parsed.port
+        if port is None:
+            port = 8443 if parsed.scheme.endswith("s") else 8123
+
+        return {
+            "host": parsed.hostname or "localhost",
+            "port": port,
+            "username": parsed.username or "default",
+            "password": parsed.password or "",
+            "database": database,
+            "secure": parsed.scheme.endswith("s"),
+        }
+
+    async def _ensure_client(self) -> clickhouse_connect.driver.Client:
+        if self._client is None:
+            async with self._lock:
+                if self._client is None:
+                    try:
+                        self._client = await asyncio.to_thread(
+                            clickhouse_connect.get_client, **self._client_kwargs()
+                        )
+                    except Exception as exc:  # pragma: no cover - network errors
+                        raise FeedbackStorageError("Не удалось подключиться к ClickHouse.") from exc
+        assert self._client is not None
+        return self._client
+
+    async def save_feedback(self, payload: FeedbackPayload) -> FeedbackRecord:
+        client = await self._ensure_client()
+        record_id = uuid4()
+        record = FeedbackRecord.create(record_id=record_id, payload=payload)
+
+        data = [
+            [
+                str(record.id),
+                record.conversation_id,
+                record.message_id,
+                record.rating.value,
+                record.assistant_message,
+                record.user_message,
+                record.comment,
+                record.mode,
+                record.created_at,
+            ]
+        ]
+        columns = [
+            "id",
+            "conversation_id",
+            "message_id",
+            "rating",
+            "assistant_message",
+            "user_message",
+            "comment",
+            "mode",
+            "created_at",
+        ]
+
+        try:
+            await asyncio.to_thread(client.insert, "feedback", data, column_names=columns)
+        except Exception as exc:  # pragma: no cover - network errors
+            raise FeedbackStorageError("Не удалось сохранить отзыв в ClickHouse.") from exc
+
+        return record
+
+    async def close(self) -> None:
+        if self._client is not None:
+            await asyncio.to_thread(self._client.close)
+            self._client = None
+
+
+_storage_instance: Optional[FeedbackStorage] = None
+_storage_lock = asyncio.Lock()
+
+
+def _create_storage_from_env() -> FeedbackStorage:
+    dsn = os.getenv("FEEDBACK_DATABASE_URL")
+    if not dsn:
+        raise FeedbackStorageError(
+            "Не задана переменная окружения FEEDBACK_DATABASE_URL для подключения к базе."
+        )
+
+    scheme = urlparse(dsn).scheme.lower()
+
+    if scheme.startswith("postgres"):
+        return PostgresFeedbackStorage(dsn)
+
+    if scheme.startswith("clickhouse"):
+        return ClickHouseFeedbackStorage(dsn)
+
+    raise FeedbackStorageError(
+        "Поддерживаются только подключения PostgreSQL (postgres://) и ClickHouse (clickhouse://)."
+    )
+
+
+async def get_feedback_storage() -> AsyncIterator[FeedbackStorage]:
+    """FastAPI dependency that returns a cached storage instance."""
+
+    global _storage_instance
+
+    if _storage_instance is None:
+        async with _storage_lock:
+            if _storage_instance is None:
+                _storage_instance = _create_storage_from_env()
+
+    assert _storage_instance is not None
+    yield _storage_instance
+
+
+async def shutdown_feedback_storage() -> None:
+    """Dispose the cached storage instance during application shutdown."""
+
+    global _storage_instance
+    if _storage_instance is not None:
+        await _storage_instance.close()
+        _storage_instance = None
+
+
+__all__ = [
+    "ClickHouseFeedbackStorage",
+    "FeedbackStorage",
+    "FeedbackStorageError",
+    "PostgresFeedbackStorage",
+    "get_feedback_storage",
+    "shutdown_feedback_storage",
+]

--- a/backend/feedback_service/main.py
+++ b/backend/feedback_service/main.py
@@ -1,0 +1,59 @@
+"""FastAPI application exposing the feedback submission endpoint."""
+
+from __future__ import annotations
+
+import logging
+from contextlib import asynccontextmanager
+
+from fastapi import Depends, FastAPI, HTTPException, status
+from fastapi.middleware.cors import CORSMiddleware
+
+from .database import FeedbackStorageError, shutdown_feedback_storage
+from .repository import FeedbackRepository, get_repository
+from .schemas import FeedbackPayload, FeedbackResponse
+
+logger = logging.getLogger(__name__)
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    """Clean up shared resources on shutdown."""
+
+    yield
+    await shutdown_feedback_storage()
+
+
+app = FastAPI(title="Kolibri Feedback API", version="1.0.0", lifespan=lifespan)
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["POST", "OPTIONS"],
+    allow_headers=["*"]
+)
+
+
+@app.post("/api/feedback", response_model=FeedbackResponse, status_code=status.HTTP_201_CREATED)
+async def submit_feedback(
+    payload: FeedbackPayload,
+    repository: FeedbackRepository = Depends(get_repository),
+):
+    """Persist feedback and append it to the RLHF dataset."""
+
+    try:
+        await repository.create_feedback(payload)
+    except FeedbackStorageError as error:
+        logger.exception("Feedback persistence failed: %s", error)
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(error)) from error
+    except Exception as error:  # pragma: no cover - defensive logging
+        logger.exception("Unexpected error while handling feedback: %s", error)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Не удалось сохранить отзыв.",
+        ) from error
+
+    return FeedbackResponse()
+
+
+__all__ = ["app"]

--- a/backend/feedback_service/repository.py
+++ b/backend/feedback_service/repository.py
@@ -1,0 +1,38 @@
+"""Repository coordinating feedback persistence and dataset export."""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import Depends
+
+from .database import FeedbackStorage, FeedbackStorageError, get_feedback_storage
+from .rlhf_dataset import RLHFDatasetWriter, get_dataset_writer
+from .schemas import FeedbackPayload, FeedbackRecord
+
+
+class FeedbackRepository:
+    """High level orchestrator combining database storage and RLHF export."""
+
+    def __init__(self, storage: FeedbackStorage, dataset_writer: RLHFDatasetWriter) -> None:
+        self._storage = storage
+        self._dataset_writer = dataset_writer
+
+    async def create_feedback(self, payload: FeedbackPayload) -> FeedbackRecord:
+        """Persist the payload and mirror it into the RLHF dataset."""
+
+        record = await self._storage.save_feedback(payload)
+        await self._dataset_writer.append(record)
+        return record
+
+
+async def get_repository(
+    storage: Annotated[FeedbackStorage, Depends(get_feedback_storage)],
+    dataset_writer: Annotated[RLHFDatasetWriter, Depends(get_dataset_writer)],
+) -> FeedbackRepository:
+    """FastAPI dependency constructing a feedback repository instance."""
+
+    return FeedbackRepository(storage, dataset_writer)
+
+
+__all__ = ["FeedbackRepository", "FeedbackStorageError", "get_repository"]

--- a/backend/feedback_service/rlhf_dataset.py
+++ b/backend/feedback_service/rlhf_dataset.py
@@ -1,0 +1,59 @@
+"""Helpers for appending feedback into an RLHF training dataset."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from pathlib import Path
+from typing import Optional
+
+from .schemas import FeedbackRecord
+
+
+class RLHFDatasetWriter:
+    """Append feedback records into a JSONL dataset for RLHF pipelines."""
+
+    def __init__(self, dataset_path: Optional[Path] = None) -> None:
+        default_path = Path("data/rlhf_feedback.jsonl")
+        if dataset_path is not None:
+            path = dataset_path
+        else:
+            env_path = os.getenv("RLHF_DATASET_PATH")
+            path = Path(env_path) if env_path else default_path
+
+        path.parent.mkdir(parents=True, exist_ok=True)
+        self._path = path
+
+    async def append(self, record: FeedbackRecord) -> None:
+        """Append the supplied feedback record to the dataset file."""
+
+        payload = {
+            "id": str(record.id),
+            "conversation_id": record.conversation_id,
+            "message_id": record.message_id,
+            "rating": record.rating.value,
+            "assistant_message": record.assistant_message,
+            "user_message": record.user_message,
+            "comment": record.comment,
+            "mode": record.mode,
+            "created_at": record.created_at.isoformat(),
+        }
+
+        await asyncio.to_thread(self._append_sync, payload)
+
+    def _append_sync(self, payload: dict[str, object]) -> None:
+        with self._path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(payload, ensure_ascii=False) + "\n")
+
+
+_dataset_writer = RLHFDatasetWriter()
+
+
+async def get_dataset_writer() -> RLHFDatasetWriter:
+    """FastAPI dependency returning a shared dataset writer."""
+
+    return _dataset_writer
+
+
+__all__ = ["RLHFDatasetWriter", "get_dataset_writer"]

--- a/backend/feedback_service/schemas.py
+++ b/backend/feedback_service/schemas.py
@@ -1,0 +1,97 @@
+"""Data models for the Kolibri feedback API."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Literal, Optional
+from uuid import UUID
+
+from pydantic import BaseModel, Field, field_validator
+
+
+class FeedbackRating(str, Enum):
+    """Possible rating values supplied by the UI."""
+
+    USEFUL = "useful"
+    NOT_USEFUL = "not_useful"
+
+
+class FeedbackPayload(BaseModel):
+    """Incoming payload describing feedback for a single assistant message."""
+
+    conversation_id: str = Field(..., min_length=1, max_length=128)
+    message_id: str = Field(..., min_length=1, max_length=128)
+    rating: FeedbackRating
+    assistant_message: str = Field(..., min_length=1)
+    user_message: Optional[str] = Field(default=None)
+    comment: Optional[str] = Field(default=None, max_length=1000)
+    mode: Optional[str] = Field(default=None, max_length=128)
+
+    @field_validator("user_message")
+    @classmethod
+    def _strip_optional(cls, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return None
+        stripped = value.strip()
+        return stripped or None
+
+    @field_validator("comment")
+    @classmethod
+    def _normalise_comment(cls, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return None
+        stripped = value.strip()
+        return stripped or None
+
+
+class FeedbackResponse(BaseModel):
+    """Response returned by the API after successful persistence."""
+
+    status: Literal["ok"] = "ok"
+
+
+@dataclass(slots=True)
+class FeedbackRecord:
+    """Canonical representation of stored feedback used across the pipeline."""
+
+    id: UUID
+    conversation_id: str
+    message_id: str
+    rating: FeedbackRating
+    assistant_message: str
+    user_message: Optional[str]
+    comment: Optional[str]
+    mode: Optional[str]
+    created_at: datetime
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        record_id: UUID,
+        payload: FeedbackPayload,
+        created_at: Optional[datetime] = None,
+    ) -> "FeedbackRecord":
+        """Build a record instance from the incoming payload."""
+
+        return cls(
+            id=record_id,
+            conversation_id=payload.conversation_id,
+            message_id=payload.message_id,
+            rating=payload.rating,
+            assistant_message=payload.assistant_message,
+            user_message=payload.user_message,
+            comment=payload.comment,
+            mode=payload.mode,
+            created_at=created_at or datetime.now(timezone.utc),
+        )
+
+
+__all__ = [
+    "FeedbackPayload",
+    "FeedbackRating",
+    "FeedbackRecord",
+    "FeedbackResponse",
+]

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,6 +13,7 @@ const App = () => {
   const [mode, setMode] = useState("Быстрый ответ");
   const [isProcessing, setIsProcessing] = useState(false);
   const [bridgeReady, setBridgeReady] = useState(false);
+  const [conversationId, setConversationId] = useState(() => crypto.randomUUID());
 
   useEffect(() => {
     let cancelled = false;
@@ -51,6 +52,7 @@ const App = () => {
     if (!bridgeReady) {
       setMessages([]);
       setDraft("");
+      setConversationId(crypto.randomUUID());
       setIsProcessing(false);
       return;
     }
@@ -60,6 +62,7 @@ const App = () => {
         await kolibriBridge.reset();
         setMessages([]);
         setDraft("");
+        setConversationId(crypto.randomUUID());
       } catch (error) {
         const assistantMessage: ChatMessage = {
           id: crypto.randomUUID(),
@@ -101,6 +104,7 @@ const App = () => {
         role: "assistant",
         content: answer,
         timestamp: new Date().toLocaleTimeString("ru-RU", { hour: "2-digit", minute: "2-digit" }),
+        mode,
       };
       setMessages((prev) => [...prev, assistantMessage]);
     } catch (error) {
@@ -124,8 +128,14 @@ const App = () => {
       return <WelcomeScreen onSuggestionSelect={handleSuggestionSelect} />;
     }
 
-    return <ChatView messages={messages} isLoading={isProcessing} />;
-  }, [handleSuggestionSelect, isProcessing, messages]);
+    return (
+      <ChatView
+        messages={messages}
+        isLoading={isProcessing}
+        conversationId={conversationId}
+      />
+    );
+  }, [conversationId, handleSuggestionSelect, isProcessing, messages]);
 
   return (
     <Layout sidebar={<Sidebar />}>

--- a/frontend/src/components/ChatMessage.tsx
+++ b/frontend/src/components/ChatMessage.tsx
@@ -1,10 +1,13 @@
+import FeedbackForm from "./FeedbackForm";
 import type { ChatMessage as ChatMessageModel } from "../types/chat";
 
 interface ChatMessageProps {
   message: ChatMessageModel;
+  conversationId: string;
+  latestUserMessage?: ChatMessageModel;
 }
 
-const ChatMessage = ({ message }: ChatMessageProps) => {
+const ChatMessage = ({ message, conversationId, latestUserMessage }: ChatMessageProps) => {
   const isUser = message.role === "user";
 
   return (
@@ -19,6 +22,13 @@ const ChatMessage = ({ message }: ChatMessageProps) => {
       <div className="rounded-2xl bg-white/80 p-4 shadow-card">
         <p className="whitespace-pre-line text-sm leading-relaxed text-text-dark">{message.content}</p>
         <p className="mt-2 text-xs text-text-light">{message.timestamp}</p>
+        {!isUser && (
+          <FeedbackForm
+            conversationId={conversationId}
+            message={message}
+            latestUserMessage={latestUserMessage}
+          />
+        )}
       </div>
     </div>
   );

--- a/frontend/src/components/ChatView.tsx
+++ b/frontend/src/components/ChatView.tsx
@@ -1,13 +1,14 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import type { ChatMessage } from "../types/chat";
 import ChatMessageView from "./ChatMessage";
 
 interface ChatViewProps {
   messages: ChatMessage[];
   isLoading: boolean;
+  conversationId: string;
 }
 
-const ChatView = ({ messages, isLoading }: ChatViewProps) => {
+const ChatView = ({ messages, isLoading, conversationId }: ChatViewProps) => {
   const containerRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
@@ -20,12 +21,29 @@ const ChatView = ({ messages, isLoading }: ChatViewProps) => {
     container.scrollTop = container.scrollHeight;
   }, [messages, isLoading]);
 
+  const renderedMessages = useMemo(() => {
+    let lastUserMessage: ChatMessage | undefined;
+    return messages.map((message) => {
+      const contextUserMessage = message.role === "assistant" ? lastUserMessage : undefined;
+      if (message.role === "user") {
+        lastUserMessage = message;
+      }
+
+      return (
+        <ChatMessageView
+          key={message.id}
+          message={message}
+          conversationId={conversationId}
+          latestUserMessage={contextUserMessage}
+        />
+      );
+    });
+  }, [conversationId, messages]);
+
   return (
     <section className="flex h-full flex-col rounded-3xl bg-white/70 p-8 shadow-card">
       <div className="flex-1 space-y-6 overflow-y-auto pr-2" ref={containerRef}>
-        {messages.map((message) => (
-          <ChatMessageView key={message.id} message={message} />
-        ))}
+        {renderedMessages}
         {isLoading && (
           <div className="flex items-center gap-3 text-sm text-text-light">
             <span className="h-2 w-2 animate-pulse rounded-full bg-primary" />

--- a/frontend/src/components/FeedbackForm.tsx
+++ b/frontend/src/components/FeedbackForm.tsx
@@ -1,0 +1,129 @@
+import { FormEvent, useCallback, useState } from "react";
+import { twMerge } from "tailwind-merge";
+import { submitFeedback } from "../core/api";
+import type { ChatMessage } from "../types/chat";
+import type { FeedbackRating } from "../types/feedback";
+
+interface FeedbackFormProps {
+  conversationId: string;
+  message: ChatMessage;
+  latestUserMessage?: ChatMessage;
+}
+
+const ratingLabels: Record<FeedbackRating, string> = {
+  useful: "Полезно",
+  not_useful: "Не полезно",
+};
+
+const FeedbackForm = ({ conversationId, message, latestUserMessage }: FeedbackFormProps) => {
+  const [rating, setRating] = useState<FeedbackRating | null>(null);
+  const [comment, setComment] = useState("");
+  const [status, setStatus] = useState<"idle" | "submitting" | "success">("idle");
+  const [error, setError] = useState<string | null>(null);
+
+  const isSubmitting = status === "submitting";
+  const isCompleted = status === "success";
+
+  const assistantMessage = message.content.trim();
+  const userMessage = latestUserMessage?.content?.trim() || undefined;
+
+  const handleRatingSelect = useCallback((value: FeedbackRating) => {
+    setRating((current) => (current === value ? null : value));
+    setError(null);
+  }, []);
+
+  const handleSubmit = useCallback(
+    async (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+
+      if (!rating) {
+        setError("Пожалуйста, выберите оценку ответа.");
+        return;
+      }
+
+      setStatus("submitting");
+      setError(null);
+
+      try {
+        await submitFeedback({
+          conversationId,
+          messageId: message.id,
+          assistantMessage,
+          userMessage,
+          rating,
+          comment: comment.trim() || undefined,
+          mode: message.mode,
+        });
+        setStatus("success");
+      } catch (feedbackError) {
+        setStatus("idle");
+        setError(
+          feedbackError instanceof Error
+            ? feedbackError.message
+            : "Не удалось отправить отзыв. Попробуйте ещё раз.",
+        );
+      }
+    },
+    [assistantMessage, comment, conversationId, message.id, message.mode, rating, userMessage],
+  );
+
+  if (!assistantMessage.length) {
+    return null;
+  }
+
+  return (
+    <form className="mt-4 space-y-3 rounded-xl bg-background-light/60 p-4" onSubmit={handleSubmit}>
+      <p className="text-sm font-medium text-text-dark">Оцените ответ</p>
+      <div className="flex flex-wrap gap-3">
+        {(Object.keys(ratingLabels) as FeedbackRating[]).map((value) => {
+          const isSelected = rating === value;
+          return (
+            <button
+              key={value}
+              type="button"
+              className={twMerge(
+                "rounded-full border border-primary px-4 py-2 text-sm font-medium transition-colors",
+                isSelected ? "bg-primary text-white" : "bg-white text-primary hover:bg-primary/10",
+                (isSubmitting || isCompleted) && "cursor-not-allowed opacity-70",
+              )}
+              onClick={() => handleRatingSelect(value)}
+              disabled={isSubmitting || isCompleted}
+            >
+              {ratingLabels[value]}
+            </button>
+          );
+        })}
+      </div>
+
+      <label className="block text-sm text-text-light">
+        <span className="mb-1 block">Комментарий (необязательно)</span>
+        <textarea
+          className="h-24 w-full resize-none rounded-xl border border-border-light bg-white/90 p-3 text-sm text-text-dark focus:border-primary focus:outline-none"
+          placeholder="Поделитесь деталями, чтобы помочь нам улучшить ответы"
+          value={comment}
+          onChange={(event) => setComment(event.target.value)}
+          disabled={isSubmitting || isCompleted}
+          maxLength={1000}
+        />
+      </label>
+
+      {error && <p className="text-sm text-accent-coral">{error}</p>}
+
+      <div className="flex items-center gap-3">
+        <button
+          type="submit"
+          className={twMerge(
+            "rounded-full bg-primary px-5 py-2 text-sm font-semibold text-white transition-opacity",
+            (isSubmitting || isCompleted || !rating) && "opacity-70",
+          )}
+          disabled={isSubmitting || isCompleted || !rating}
+        >
+          {isSubmitting ? "Отправка..." : isCompleted ? "Отправлено" : "Отправить"}
+        </button>
+        {isCompleted && <span className="text-sm text-text-light">Спасибо за отзыв!</span>}
+      </div>
+    </form>
+  );
+};
+
+export default FeedbackForm;

--- a/frontend/src/core/api.ts
+++ b/frontend/src/core/api.ts
@@ -1,0 +1,33 @@
+import type { FeedbackRequest } from "../types/feedback";
+
+const API_BASE_URL = (import.meta.env.VITE_API_BASE_URL ?? "").replace(/\/$/, "");
+const FEEDBACK_ENDPOINT = "/api/feedback";
+
+const buildUrl = (endpoint: string) => `${API_BASE_URL}${endpoint}`;
+
+export const submitFeedback = async (payload: FeedbackRequest): Promise<void> => {
+  const response = await fetch(buildUrl(FEEDBACK_ENDPOINT), {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(payload),
+  });
+
+  if (response.ok) {
+    return;
+  }
+
+  let detail = "Не удалось сохранить отзыв.";
+
+  try {
+    const data = (await response.json()) as { detail?: string } | undefined;
+    if (data?.detail) {
+      detail = data.detail;
+    }
+  } catch (error) {
+    // Игнорируем ошибки парсинга и используем сообщение по умолчанию.
+  }
+
+  throw new Error(detail);
+};

--- a/frontend/src/types/chat.ts
+++ b/frontend/src/types/chat.ts
@@ -5,4 +5,5 @@ export interface ChatMessage {
   role: ChatRole;
   content: string;
   timestamp: string;
+  mode?: string;
 }

--- a/frontend/src/types/feedback.ts
+++ b/frontend/src/types/feedback.ts
@@ -1,0 +1,11 @@
+export type FeedbackRating = "useful" | "not_useful";
+
+export interface FeedbackRequest {
+  conversationId: string;
+  messageId: string;
+  rating: FeedbackRating;
+  assistantMessage: string;
+  userMessage?: string;
+  comment?: string;
+  mode?: string;
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,11 @@
 # are required.
 
 # Инструменты Python, используемые Kolibri OS для тестов и статического анализа.
+asyncpg>=0.29,<0.30
+clickhouse-connect>=0.6,<0.7
 coverage[toml]>=7.4,<8
+fastapi>=0.110,<0.112
 pyright>=1.1.350,<1.2
 pytest>=7.4,<9
 ruff>=0.4.0,<0.5
+uvicorn[standard]>=0.29,<0.30


### PR DESCRIPTION
## Summary
- add a feedback form under assistant replies with Полезно/Не полезно buttons and comment submission wired to a new API client
- introduce a FastAPI-based feedback service that stores ratings in PostgreSQL or ClickHouse and mirrors them into an RLHF dataset file
- extend shared types, configuration, and dependencies to support the feedback workflow across the stack

## Testing
- npm run lint
- python -m compileall backend/feedback_service

------
https://chatgpt.com/codex/tasks/task_e_68dbd141c32483238c4a445b650c7e33