### PR TITLE
Add Kolibri Script lexer and signing tests

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -1,0 +1,31 @@
+"""Конфигурация Kolibri Script."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import lru_cache
+import os
+
+
+@dataclass(frozen=True)
+class KolibriConfig:
+    """Конфигурация ядра Kolibri."""
+
+    script_secret: bytes
+
+    @staticmethod
+    def from_env() -> "KolibriConfig":
+        secret = os.getenv("KOLIBRI_SCRIPT_SECRET", "kolibri-script-secret")
+        return KolibriConfig(script_secret=secret.encode("utf-8"))
+
+
+@lru_cache(maxsize=1)
+def get_config() -> KolibriConfig:
+    """Возвращает конфигурацию с мемоизацией."""
+
+    return KolibriConfig.from_env()
+
+
+def get_secret() -> bytes:
+    """Возвращает секрет для HMAC-подписи Kolibri Script."""
+
+    return get_config().script_secret

--- a/core/kolibri_script/__init__.py
+++ b/core/kolibri_script/__init__.py
@@ -1,0 +1,21 @@
+"""Лексический разбор Kolibri Script."""
+
+from .lexer import (
+    KEYWORDS,
+    SYMBOLS,
+    Token,
+    TokenizationError,
+    tokenize_ksd,
+    KolibriScriptEnvelope,
+    hmac_wrap_ksd,
+)
+
+__all__ = [
+    "KEYWORDS",
+    "SYMBOLS",
+    "Token",
+    "TokenizationError",
+    "tokenize_ksd",
+    "KolibriScriptEnvelope",
+    "hmac_wrap_ksd",
+]

--- a/core/kolibri_script/lexer.py
+++ b/core/kolibri_script/lexer.py
@@ -1,0 +1,345 @@
+"""Лексический анализатор Kolibri Script.
+
+Модуль предоставляет:
+* таблицу ключевых слов;
+* конечные автоматы для чисел и строк;
+* генератор токенов для файлов с расширением ``.ksd``;
+* HMAC-обёртку, обеспечивающую целостность результата разбора.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+import base64
+import hashlib
+import hmac
+import json
+from typing import Dict, Iterator, List, Mapping, MutableMapping, Optional, Sequence, Tuple
+
+from core.config import get_secret
+
+KEYWORDS: Mapping[str, str] = {
+    "let": "LET",
+    "fn": "FUNCTION",
+    "return": "RETURN",
+    "if": "IF",
+    "else": "ELSE",
+    "for": "FOR",
+    "while": "WHILE",
+    "break": "BREAK",
+    "continue": "CONTINUE",
+    "true": "BOOLEAN",
+    "false": "BOOLEAN",
+    "null": "NULL",
+}
+
+SYMBOLS: Mapping[str, str] = {
+    "(": "LPAREN",
+    ")": "RPAREN",
+    "{": "LBRACE",
+    "}": "RBRACE",
+    "[": "LBRACKET",
+    "]": "RBRACKET",
+    ",": "COMMA",
+    ":": "COLON",
+    ";": "SEMICOLON",
+    "+": "PLUS",
+    "-": "MINUS",
+    "*": "STAR",
+    "/": "SLASH",
+    "%": "PERCENT",
+    "<": "LT",
+    ">": "GT",
+    "=": "ASSIGN",
+}
+
+MULTI_CHAR_SYMBOLS: Mapping[str, str] = {
+    "==": "EQ",
+    "!=": "NEQ",
+    "<=": "LE",
+    ">=": "GE",
+    "->": "ARROW",
+}
+
+ESCAPE_SEQUENCES: Mapping[str, str] = {
+    "\\": "\\",
+    '"': '"',
+    "n": "\n",
+    "r": "\r",
+    "t": "\t",
+}
+
+
+@dataclass(frozen=True)
+class Token:
+    """Единица лексического анализа."""
+
+    type: str
+    value: str
+    position: Tuple[int, int]
+
+
+class TokenizationError(ValueError):
+    """Ошибка лексического анализа."""
+
+
+class _NumberAutomaton:
+    """DFA для числовых литералов."""
+
+    _TRANSITIONS: Mapping[Tuple[str, str], str] = {
+        ("start", "sign"): "signed",
+        ("start", "digit"): "int",
+        ("signed", "digit"): "int",
+        ("int", "digit"): "int",
+        ("int", "dot"): "dot",
+        ("int", "exp"): "exp",
+        ("dot", "digit"): "frac",
+        ("frac", "digit"): "frac",
+        ("frac", "exp"): "exp",
+        ("exp", "sign"): "exp_sign",
+        ("exp", "digit"): "exp_digit",
+        ("exp_sign", "digit"): "exp_digit",
+        ("exp_digit", "digit"): "exp_digit",
+    }
+
+    def __init__(self) -> None:
+        self._accepting = {"int", "frac", "exp_digit"}
+        self._start_state = "start"
+
+    def _categorize(self, state: str, char: str) -> str:
+        if char.isdigit():
+            return "digit"
+        if char in "+-":
+            return "sign"
+        if char in "eE":
+            return "exp"
+        if char == ".":
+            return "dot"
+        return "invalid"
+
+    def consume(self, text: str) -> Tuple[str, int]:
+        state = self._start_state
+        idx = 0
+        buffer: List[str] = []
+        length = len(text)
+        while idx < length:
+            char = text[idx]
+            category = self._categorize(state, char)
+            next_state = self._TRANSITIONS.get((state, category))
+            if next_state is None:
+                break
+            state = next_state
+            buffer.append(char)
+            idx += 1
+        if state not in self._accepting:
+            raise TokenizationError(f"Некорректное число: {text[:idx+1]!r}")
+        return "".join(buffer), idx
+
+
+class _StringAutomaton:
+    """Специализированный DFA для строковых литералов."""
+
+    def consume(self, text: str) -> Tuple[str, int]:
+        if not text or text[0] != '"':
+            raise TokenizationError("Строка должна начинаться с кавычки")
+        state = "start"
+        idx = 0
+        buffer: List[str] = []
+        length = len(text)
+        while idx < length:
+            char = text[idx]
+            if state == "start":
+                state = "body"
+                idx += 1
+                continue
+            if state == "body":
+                if char == '"':
+                    idx += 1
+                    state = "end"
+                    break
+                if char == "\\":
+                    state = "escape"
+                    idx += 1
+                    continue
+                if char in "\n\r":
+                    raise TokenizationError("Строковый литерал не может содержать перенос строки")
+                buffer.append(char)
+                idx += 1
+                continue
+            if state == "escape":
+                replacement = ESCAPE_SEQUENCES.get(char)
+                if replacement is None:
+                    raise TokenizationError(f"Неизвестная escape-последовательность: \\{char}")
+                buffer.append(replacement)
+                state = "body"
+                idx += 1
+                continue
+        if state != "end":
+            raise TokenizationError("Незавершённый строковый литерал")
+        return "".join(buffer), idx
+
+
+_NUMBER_DFA = _NumberAutomaton()
+_STRING_DFA = _StringAutomaton()
+
+
+def _payload_to_bytes(payload: object) -> bytes:
+    if isinstance(payload, bytes):
+        return payload
+    if isinstance(payload, str):
+        return payload.encode("utf-8")
+    return json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def _normalise_secret(secret: Optional[bytes | str]) -> bytes:
+    if secret is None:
+        return get_secret()
+    if isinstance(secret, bytes):
+        return secret
+    return secret.encode("utf-8")
+
+
+@dataclass(frozen=True)
+class KolibriScriptEnvelope:
+    """Подпись и метаданные Kolibri Script."""
+
+    header: Mapping[str, object]
+    symbols: Mapping[str, int]
+    payload: bytes
+    signature: str
+
+
+def tokenize_ksd(source: str) -> Iterator[Token]:
+    """Генератор токенов для Kolibri Script."""
+
+    idx = 0
+    line = 1
+    column = 1
+    length = len(source)
+    while idx < length:
+        char = source[idx]
+        if char in " \t":
+            idx += 1
+            column += 1
+            continue
+        if char == "\n":
+            idx += 1
+            line += 1
+            column = 1
+            continue
+        start_column = column
+        remainder = source[idx:]
+
+        matched_symbol: Optional[str] = None
+        for symbol in sorted(MULTI_CHAR_SYMBOLS, key=len, reverse=True):
+            if remainder.startswith(symbol):
+                matched_symbol = symbol
+                break
+        if matched_symbol is not None:
+            idx += len(matched_symbol)
+            column += len(matched_symbol)
+            yield Token(MULTI_CHAR_SYMBOLS[matched_symbol], matched_symbol, (line, start_column))
+            continue
+
+        if char.isalpha() or char == "_":
+            identifier: List[str] = []
+            while idx < length and (source[idx].isalnum() or source[idx] == "_"):
+                identifier.append(source[idx])
+                idx += 1
+                column += 1
+            value = "".join(identifier)
+            token_type = KEYWORDS.get(value, "IDENTIFIER")
+            yield Token(token_type, value, (line, start_column))
+            continue
+
+        if char.isdigit() or (char in "+-" and idx + 1 < length and source[idx + 1].isdigit()):
+            lexeme, consumed = _NUMBER_DFA.consume(remainder)
+            following = source[idx + consumed: idx + consumed + 1]
+            if following and (following[0].isalpha() or following[0] == "_"):
+                raise TokenizationError("Цифровой литерал должен завершаться до идентификатора")
+            idx += consumed
+            column += consumed
+            yield Token("NUMBER", lexeme, (line, start_column))
+            continue
+
+        if char == '"':
+            value, consumed = _STRING_DFA.consume(remainder)
+            idx += consumed
+            column += consumed
+            yield Token("STRING", value, (line, start_column))
+            continue
+
+        if char == "#":
+            # Комментарий до конца строки
+            while idx < length and source[idx] != "\n":
+                idx += 1
+            continue
+
+        token_type = SYMBOLS.get(char)
+        if token_type:
+            idx += 1
+            column += 1
+            yield Token(token_type, char, (line, start_column))
+            continue
+
+        raise TokenizationError(f"Неизвестный символ {char!r} на {line}:{start_column}")
+
+
+def hmac_wrap_ksd(
+    tokens: Sequence[Token],
+    payload: object,
+    secret: Optional[bytes | str] = None,
+) -> KolibriScriptEnvelope:
+    """Создаёт HMAC-обёртку для токенов и полезной нагрузки."""
+
+    secret_bytes = _normalise_secret(secret)
+    payload_bytes = _payload_to_bytes(payload)
+
+    header: Dict[str, object] = {
+        "alg": "HS256",
+        "version": 1,
+        "token_count": len(tokens),
+    }
+
+    symbols: MutableMapping[str, int] = {}
+    for token in tokens:
+        if token.type == "IDENTIFIER" and token.value not in symbols:
+            symbols[token.value] = len(symbols)
+
+    canonical_tokens = [
+        {
+            "type": token.type,
+            "value": token.value,
+            "line": token.position[0],
+            "column": token.position[1],
+        }
+        for token in tokens
+    ]
+
+    canonical_payload = base64.b64encode(payload_bytes).decode("ascii")
+
+    canonical_document = json.dumps(
+        {
+            "header": header,
+            "symbols": symbols,
+            "tokens": canonical_tokens,
+            "payload": canonical_payload,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    ).encode("utf-8")
+
+    signature = hmac.new(secret_bytes, canonical_document, hashlib.sha256).hexdigest()
+
+    return KolibriScriptEnvelope(header=header, symbols=dict(symbols), payload=payload_bytes, signature=signature)
+
+
+__all__ = [
+    "KEYWORDS",
+    "SYMBOLS",
+    "Token",
+    "TokenizationError",
+    "tokenize_ksd",
+    "KolibriScriptEnvelope",
+    "hmac_wrap_ksd",
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ coverage[toml]>=7.4,<8
 pyright>=1.1.350,<1.2
 pytest>=7.4,<9
 ruff>=0.4.0,<0.5
+hypothesis>=6.88,<7

--- a/tests/kolibri_script/test_lexer.py
+++ b/tests/kolibri_script/test_lexer.py
@@ -1,0 +1,111 @@
+import json
+import sys
+from pathlib import Path
+
+import pytest
+from hypothesis import assume, given, settings, strategies as st
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from core.kolibri_script.lexer import (
+    KEYWORDS,
+    TokenizationError,
+    hmac_wrap_ksd,
+    tokenize_ksd,
+)
+
+
+def _collect(tokens):
+    return [(token.type, token.value) for token in tokens]
+
+
+def test_tokenize_basic_script():
+    script = 'let answer = 42\nprint("kolibri")\nif answer >= 10 { return answer }'
+    tokens = list(tokenize_ksd(script))
+    assert _collect(tokens[:4]) == [
+        ("LET", "let"),
+        ("IDENTIFIER", "answer"),
+        ("ASSIGN", "="),
+        ("NUMBER", "42"),
+    ]
+    assert tokens[4].type == "IDENTIFIER"
+    assert tokens[4].value == "print"
+    assert any(token.type == "STRING" and token.value == "kolibri" for token in tokens)
+    relational = [token for token in tokens if token.type in {"GE", "GT", "LE", "LT"}]
+    assert relational and relational[0].type == "GE"
+
+
+def test_unterminated_string_raises():
+    with pytest.raises(TokenizationError):
+        list(tokenize_ksd('let text = "oops'))
+
+
+def test_number_with_trailing_identifier_is_error():
+    with pytest.raises(TokenizationError):
+        list(tokenize_ksd("let value = 12abc"))
+
+
+def test_hmac_envelope_contains_metadata():
+    tokens = list(tokenize_ksd("let value = 10"))
+    payload = {"module": "demo"}
+    envelope = hmac_wrap_ksd(tokens, payload, secret=b"secret-key")
+    assert envelope.header["alg"] == "HS256"
+    assert envelope.header["token_count"] == len(tokens)
+    assert envelope.symbols == {"value": 0}
+    assert envelope.payload == json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    assert len(envelope.signature) == 64
+
+
+IDENTIFIER_CHARS = st.characters(min_codepoint=ord("a"), max_codepoint=ord("z"))
+STRING_BODY = st.text(alphabet=st.characters(min_codepoint=32, max_codepoint=126).filter(lambda c: c not in {'"', '\\'}), max_size=5)
+
+
+def _identifier_strategy():
+    return (
+        st.text(alphabet=IDENTIFIER_CHARS, min_size=1, max_size=5)
+        .filter(lambda s: s not in KEYWORDS)
+    )
+
+
+def _string_literal_strategy():
+    return STRING_BODY.map(lambda s: '"' + s + '"')
+
+
+def _number_strategy():
+    return st.one_of(
+        st.integers(min_value=-1000, max_value=1000).map(str),
+        st.floats(allow_nan=False, allow_infinity=False, width=32).map(lambda f: format(f, "g")),
+    )
+
+
+def _symbol_strategy():
+    return st.sampled_from(list({"=", "+", "-", "*", "/", "(", ")", "{", "}", ",", ":", "==", "!=", "<=", ">=", "->"}))
+
+
+def _token_strategy():
+    return st.one_of(
+        st.sampled_from(list(KEYWORDS.keys())),
+        _identifier_strategy(),
+        _string_literal_strategy(),
+        _number_strategy(),
+        _symbol_strategy(),
+    )
+
+
+@settings(max_examples=75)
+@given(source=st.lists(_token_strategy(), min_size=1, max_size=8).map(lambda items: " ".join(items)), payload=st.binary(min_size=0, max_size=32), secret=st.binary(min_size=1, max_size=16))
+def test_signature_is_stable(source: str, payload: bytes, secret: bytes):
+    tokens = list(tokenize_ksd(source))
+    first = hmac_wrap_ksd(tokens, payload, secret=secret)
+    second = hmac_wrap_ksd(tokens, payload, secret=secret)
+    assert first.signature == second.signature
+
+
+@settings(max_examples=50)
+@given(source=st.lists(_token_strategy(), min_size=1, max_size=6).map(lambda items: " ".join(items)), payload=st.binary(min_size=0, max_size=16), secret_one=st.binary(min_size=1, max_size=16), secret_two=st.binary(min_size=1, max_size=16))
+def test_signature_changes_when_secret_changes(source: str, payload: bytes, secret_one: bytes, secret_two: bytes):
+    assume(secret_one != secret_two)
+    tokens = list(tokenize_ksd(source))
+    first = hmac_wrap_ksd(tokens, payload, secret=secret_one)
+    second = hmac_wrap_ksd(tokens, payload, secret=secret_two)
+    assert first.signature != second.signature


### PR DESCRIPTION
## Summary
- add a Kolibri Script lexer with keyword tables, DFAs for numbers/strings, and `.ksd` tokenization helpers
- provide an HMAC signing envelope that sources its secret from `core.config`
- cover lexer behaviour and signature stability with pytest and Hypothesis-based tests

## Testing
- pytest tests/kolibri_script/test_lexer.py

------
https://chatgpt.com/codex/tasks/task_e_68dbd6ce0d008323b7d57e5f3026a381