### PR TITLE
Add TLS transport and networking limits

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ target_include_directories(kolibri_core
 find_package(OpenSSL REQUIRED)
 find_package(Threads REQUIRED)
 
-target_link_libraries(kolibri_core PRIVATE OpenSSL::Crypto)
+target_link_libraries(kolibri_core PRIVATE OpenSSL::Crypto OpenSSL::SSL)
 
 add_executable(kolibri_node apps/kolibri_node.c)
 add_executable(ks_compiler apps/ks_compiler.c)

--- a/backend/include/kolibri/net.h
+++ b/backend/include/kolibri/net.h
@@ -48,6 +48,7 @@ int kn_share_formula(const char *host, uint16_t port, uint32_t node_id, const Ko
 typedef struct {
     int socket_fd;
     uint16_t port;
+    void *tls_ctx;
 } KolibriNetListener;
 
 int kn_listener_start(KolibriNetListener *listener, uint16_t port);

--- a/backend/src/net.c
+++ b/backend/src/net.c
@@ -7,17 +7,143 @@
 #include <arpa/inet.h>
 #include <errno.h>
 #include <netinet/in.h>
+#include <openssl/err.h>
+#include <openssl/evp.h>
+#include <openssl/ssl.h>
+#include <openssl/x509.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/time.h>
 #include <sys/select.h>
 #include <sys/socket.h>
 #include <sys/types.h>
+#include <time.h>
 #include <unistd.h>
 
 #define KOLIBRI_HEADER_SIZE 3U
 #define KOLIBRI_MAX_PAYLOAD 256U
+#define KOLIBRI_MAX_MESSAGE_SIZE (KOLIBRI_HEADER_SIZE + KOLIBRI_MAX_PAYLOAD)
+#define KOLIBRI_IO_TIMEOUT_MS 5000U
+#define KOLIBRI_TLS_CERT_DAYS_VALID 365
+#define KOLIBRI_TLS_CN "kolibri-node"
+
+static int kolibri_socket_set_timeouts(int sockfd) {
+  struct timeval tv;
+  tv.tv_sec = (time_t)(KOLIBRI_IO_TIMEOUT_MS / 1000U);
+  tv.tv_usec = (long)((KOLIBRI_IO_TIMEOUT_MS % 1000U) * 1000U);
+  if (setsockopt(sockfd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv)) < 0) {
+    return -1;
+  }
+  if (setsockopt(sockfd, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv)) < 0) {
+    return -1;
+  }
+  return 0;
+}
+
+static int kolibri_tls_configure_self_signed(SSL_CTX *ctx) {
+  int result = -1;
+  EVP_PKEY_CTX *pctx = EVP_PKEY_CTX_new_id(EVP_PKEY_RSA, NULL);
+  if (!pctx) {
+    return -1;
+  }
+
+  EVP_PKEY *pkey = NULL;
+  if (EVP_PKEY_keygen_init(pctx) <= 0 ||
+      EVP_PKEY_CTX_set_rsa_keygen_bits(pctx, 2048) <= 0 ||
+      EVP_PKEY_keygen(pctx, &pkey) <= 0) {
+    goto cleanup;
+  }
+
+  X509 *cert = X509_new();
+  if (!cert) {
+    goto cleanup;
+  }
+
+  if (X509_set_version(cert, 2L) != 1) {
+    goto cleanup_cert;
+  }
+
+  ASN1_INTEGER_set(X509_get_serialNumber(cert), (long)time(NULL));
+  if (!X509_gmtime_adj(X509_get_notBefore(cert), 0)) {
+    goto cleanup_cert;
+  }
+  if (!X509_gmtime_adj(X509_get_notAfter(cert),
+                        (long)KOLIBRI_TLS_CERT_DAYS_VALID * 24L * 60L * 60L)) {
+    goto cleanup_cert;
+  }
+
+  if (X509_set_pubkey(cert, pkey) != 1) {
+    goto cleanup_cert;
+  }
+
+  X509_NAME *name = X509_get_subject_name(cert);
+  if (!name) {
+    goto cleanup_cert;
+  }
+
+  if (X509_NAME_add_entry_by_txt(name, "CN", MBSTRING_ASC,
+                                 (const unsigned char *)KOLIBRI_TLS_CN, -1, -1,
+                                 0) != 1) {
+    goto cleanup_cert;
+  }
+
+  if (X509_set_issuer_name(cert, name) != 1) {
+    goto cleanup_cert;
+  }
+
+  if (X509_sign(cert, pkey, EVP_sha256()) <= 0) {
+    goto cleanup_cert;
+  }
+
+  if (SSL_CTX_use_certificate(ctx, cert) != 1) {
+    goto cleanup_cert;
+  }
+  if (SSL_CTX_use_PrivateKey(ctx, pkey) != 1) {
+    goto cleanup_cert;
+  }
+  if (SSL_CTX_check_private_key(ctx) != 1) {
+    goto cleanup_cert;
+  }
+
+  result = 0;
+
+cleanup_cert:
+  X509_free(cert);
+cleanup:
+  EVP_PKEY_free(pkey);
+  EVP_PKEY_CTX_free(pctx);
+  return result;
+}
+
+static SSL_CTX *kolibri_tls_create_client_ctx(void) {
+  SSL_CTX *ctx = SSL_CTX_new(TLS_client_method());
+  if (!ctx) {
+    return NULL;
+  }
+  SSL_CTX_set_min_proto_version(ctx, TLS1_2_VERSION);
+  SSL_CTX_set_options(ctx, SSL_OP_NO_COMPRESSION);
+  SSL_CTX_set_mode(ctx, SSL_MODE_AUTO_RETRY);
+  SSL_CTX_set_verify(ctx, SSL_VERIFY_NONE, NULL);
+  return ctx;
+}
+
+static SSL_CTX *kolibri_tls_create_server_ctx(void) {
+  SSL_CTX *ctx = SSL_CTX_new(TLS_server_method());
+  if (!ctx) {
+    return NULL;
+  }
+  SSL_CTX_set_min_proto_version(ctx, TLS1_2_VERSION);
+  SSL_CTX_set_options(ctx, SSL_OP_NO_COMPRESSION);
+  SSL_CTX_set_mode(ctx, SSL_MODE_AUTO_RETRY);
+  SSL_CTX_set_verify(ctx, SSL_VERIFY_NONE, NULL);
+  if (kolibri_tls_configure_self_signed(ctx) != 0) {
+    SSL_CTX_free(ctx);
+    return NULL;
+  }
+  return ctx;
+}
 
 static uint64_t kolibri_htonll(uint64_t value) {
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
@@ -49,39 +175,69 @@ static size_t kolibri_write_header(uint8_t *buffer, size_t buffer_len,
   return KOLIBRI_HEADER_SIZE;
 }
 
-static int kolibri_send_all(int sockfd, const uint8_t *data, size_t len) {
+static int kolibri_tls_write_all(SSL *ssl, const uint8_t *data, size_t len) {
+  if (!ssl) {
+    return -1;
+  }
+
+  if (len == 0) {
+    return 0;
+  }
+
+  if (!data || len > KOLIBRI_MAX_MESSAGE_SIZE) {
+    return -1;
+  }
+
   size_t sent_total = 0;
   while (sent_total < len) {
-    ssize_t sent = send(sockfd, data + sent_total, len - sent_total, 0);
-    if (sent < 0) {
-      if (errno == EINTR) {
-        continue;
-      }
-      return -1;
+    int sent = SSL_write(ssl, data + sent_total, (int)(len - sent_total));
+    if (sent > 0) {
+      sent_total += (size_t)sent;
+      continue;
     }
-    if (sent == 0) {
-      return -1;
+
+    int error = SSL_get_error(ssl, sent);
+    if (error == SSL_ERROR_WANT_READ || error == SSL_ERROR_WANT_WRITE) {
+      continue;
     }
-    sent_total += (size_t)sent;
+    if (error == SSL_ERROR_SYSCALL && errno == EINTR) {
+      continue;
+    }
+    return -1;
   }
   return 0;
 }
 
-static int kolibri_recv_all(int sockfd, uint8_t *data, size_t len) {
+static int kolibri_tls_read_all(SSL *ssl, uint8_t *data, size_t len) {
+  if (!ssl) {
+    return -1;
+  }
+
+  if (len == 0) {
+    return 0;
+  }
+
+  if (!data || len > KOLIBRI_MAX_MESSAGE_SIZE) {
+    return -1;
+  }
+
   size_t received_total = 0;
   while (received_total < len) {
-    ssize_t received = recv(sockfd, data + received_total,
-                            len - received_total, 0);
-    if (received < 0) {
-      if (errno == EINTR) {
-        continue;
-      }
-      return -1;
+    int received = SSL_read(ssl, data + received_total,
+                            (int)(len - received_total));
+    if (received > 0) {
+      received_total += (size_t)received;
+      continue;
     }
-    if (received == 0) {
-      return -1;
+
+    int error = SSL_get_error(ssl, received);
+    if (error == SSL_ERROR_WANT_READ || error == SSL_ERROR_WANT_WRITE) {
+      continue;
     }
-    received_total += (size_t)received;
+    if (error == SSL_ERROR_SYSCALL && errno == EINTR) {
+      continue;
+    }
+    return -1;
   }
   return 0;
 }
@@ -225,11 +381,17 @@ int kn_message_decode(const uint8_t *buffer, size_t buffer_len,
   return 0;
 }
 
-static int kn_send_message(int sockfd, const uint8_t *buffer, size_t len) {
-  if (!buffer || len == 0) {
+static int kn_send_message(SSL *ssl, const uint8_t *buffer, size_t len) {
+  if (!ssl) {
     return -1;
   }
-  return kolibri_send_all(sockfd, buffer, len);
+  if (len == 0) {
+    return 0;
+  }
+  if (!buffer || len > KOLIBRI_MAX_MESSAGE_SIZE) {
+    return -1;
+  }
+  return kolibri_tls_write_all(ssl, buffer, len);
 }
 
 int kn_share_formula(const char *host, uint16_t port, uint32_t node_id,
@@ -240,6 +402,11 @@ int kn_share_formula(const char *host, uint16_t port, uint32_t node_id,
 
   int sockfd = socket(AF_INET, SOCK_STREAM, 0);
   if (sockfd < 0) {
+    return -1;
+  }
+
+  if (kolibri_socket_set_timeouts(sockfd) != 0) {
+    close(sockfd);
     return -1;
   }
 
@@ -257,21 +424,55 @@ int kn_share_formula(const char *host, uint16_t port, uint32_t node_id,
     return -1;
   }
 
-  uint8_t buffer[KOLIBRI_HEADER_SIZE + KOLIBRI_MAX_PAYLOAD];
-  size_t len = kn_message_encode_hello(buffer, sizeof(buffer), node_id);
-  if (len == 0 || kn_send_message(sockfd, buffer, len) != 0) {
+  SSL_CTX *client_ctx = kolibri_tls_create_client_ctx();
+  if (!client_ctx) {
     close(sockfd);
     return -1;
+  }
+
+  SSL *ssl = SSL_new(client_ctx);
+  if (!ssl) {
+    SSL_CTX_free(client_ctx);
+    close(sockfd);
+    return -1;
+  }
+
+  bool handshake_done = false;
+  int result = -1;
+
+  if (SSL_set_fd(ssl, sockfd) != 1) {
+    goto cleanup;
+  }
+
+  if (SSL_connect(ssl) != 1) {
+    goto cleanup;
+  }
+
+  handshake_done = true;
+
+  uint8_t buffer[KOLIBRI_MAX_MESSAGE_SIZE];
+  size_t len = kn_message_encode_hello(buffer, sizeof(buffer), node_id);
+  if (len == 0 || kn_send_message(ssl, buffer, len) != 0) {
+    goto cleanup;
   }
 
   len = kn_message_encode_formula(buffer, sizeof(buffer), node_id, formula);
-  if (len == 0 || kn_send_message(sockfd, buffer, len) != 0) {
-    close(sockfd);
-    return -1;
+  if (len == 0 || kn_send_message(ssl, buffer, len) != 0) {
+    goto cleanup;
   }
 
+  result = 0;
+
+cleanup:
+  if (ssl) {
+    if (handshake_done) {
+      SSL_shutdown(ssl);
+    }
+    SSL_free(ssl);
+  }
+  SSL_CTX_free(client_ctx);
   close(sockfd);
-  return 0;
+  return result;
 }
 
 int kn_listener_start(KolibriNetListener *listener, uint16_t port) {
@@ -279,9 +480,11 @@ int kn_listener_start(KolibriNetListener *listener, uint16_t port) {
     return -1;
   }
 
+  listener->socket_fd = -1;
+  listener->tls_ctx = NULL;
+
   int sockfd = socket(AF_INET, SOCK_STREAM, 0);
   if (sockfd < 0) {
-    listener->socket_fd = -1;
     return -1;
   }
 
@@ -306,12 +509,18 @@ int kn_listener_start(KolibriNetListener *listener, uint16_t port) {
 
   if (listen(sockfd, 4) < 0) {
     close(sockfd);
-    listener->socket_fd = -1;
+    return -1;
+  }
+
+  SSL_CTX *server_ctx = kolibri_tls_create_server_ctx();
+  if (!server_ctx) {
+    close(sockfd);
     return -1;
   }
 
   listener->socket_fd = sockfd;
   listener->port = port;
+  listener->tls_ctx = server_ctx;
   return 0;
 }
 
@@ -349,25 +558,59 @@ int kn_listener_poll(KolibriNetListener *listener, uint32_t timeout_ms,
     return -1;
   }
 
-  uint8_t buffer[KOLIBRI_HEADER_SIZE + KOLIBRI_MAX_PAYLOAD];
+  if (kolibri_socket_set_timeouts(client_fd) != 0) {
+    close(client_fd);
+    return -1;
+  }
 
+  SSL_CTX *server_ctx = (SSL_CTX *)listener->tls_ctx;
+  if (!server_ctx) {
+    close(client_fd);
+    return -1;
+  }
+
+  SSL *ssl = SSL_new(server_ctx);
+  if (!ssl) {
+    close(client_fd);
+    return -1;
+  }
+
+  bool handshake_done = false;
+  int result = -1;
+
+  if (SSL_set_fd(ssl, client_fd) != 1) {
+    goto cleanup;
+  }
+
+  if (SSL_accept(ssl) != 1) {
+    goto cleanup;
+  }
+
+  handshake_done = true;
+
+  uint8_t buffer[KOLIBRI_MAX_MESSAGE_SIZE];
   KolibriNetMessage last_message;
   bool has_last = false;
 
   while (true) {
-    if (kolibri_recv_all(client_fd, buffer, KOLIBRI_HEADER_SIZE) != 0) {
+    if (kolibri_tls_read_all(ssl, buffer, KOLIBRI_HEADER_SIZE) != 0) {
       break;
     }
+
     uint16_t payload_len;
     memcpy(&payload_len, &buffer[1], sizeof(payload_len));
     payload_len = ntohs(payload_len);
-    if (payload_len > KOLIBRI_MAX_PAYLOAD) {
+
+    if (payload_len > KOLIBRI_MAX_PAYLOAD ||
+        (size_t)payload_len + KOLIBRI_HEADER_SIZE > KOLIBRI_MAX_MESSAGE_SIZE) {
       break;
     }
-    if (kolibri_recv_all(client_fd, buffer + KOLIBRI_HEADER_SIZE,
-                         payload_len) != 0) {
+
+    if (kolibri_tls_read_all(ssl, buffer + KOLIBRI_HEADER_SIZE, payload_len) !=
+        0) {
       break;
     }
+
     size_t message_len = KOLIBRI_HEADER_SIZE + payload_len;
     KolibriNetMessage decoded;
     if (kn_message_decode(buffer, message_len, &decoded) == 0) {
@@ -375,21 +618,28 @@ int kn_listener_poll(KolibriNetListener *listener, uint32_t timeout_ms,
       last_message = decoded;
       if (decoded.type == KOLIBRI_MSG_MIGRATE_RULE) {
         *out_message = decoded;
-        close(client_fd);
-        return 1;
+        result = 1;
+        goto cleanup;
       }
       continue;
     }
+    break;
   }
 
   if (has_last) {
     *out_message = last_message;
-    close(client_fd);
-    return 1;
+    result = 1;
   }
 
+cleanup:
+  if (ssl) {
+    if (handshake_done) {
+      SSL_shutdown(ssl);
+    }
+    SSL_free(ssl);
+  }
   close(client_fd);
-  return -1;
+  return result;
 }
 
 void kn_listener_close(KolibriNetListener *listener) {
@@ -399,5 +649,9 @@ void kn_listener_close(KolibriNetListener *listener) {
   if (listener->socket_fd >= 0) {
     close(listener->socket_fd);
   }
+  if (listener->tls_ctx) {
+    SSL_CTX_free((SSL_CTX *)listener->tls_ctx);
+  }
   listener->socket_fd = -1;
+  listener->tls_ctx = NULL;
 }

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -1,0 +1,54 @@
+# Kolibri networking
+
+This document describes the current wire protocol used by Kolibri nodes
+(transport version **2**).
+
+## Transport overview
+
+* **Transport:** TLS over TCP. Connections are established by the sender and
+  closed after the message batch is transferred.
+* **TLS configuration:** the backend generates an ephemeral RSA key and
+  self-signed X.509 certificate at runtime. Clients accept this certificate
+  without verification (suitable for trusted laboratory environments). TLS 1.2
+  is the minimum protocol version and compression is disabled.
+* **I/O timeouts:** both send and receive operations abort after 5 seconds of
+  inactivity.
+* **Message size limits:** the encoded message (header + payload) may not
+  exceed 259 bytes. Payloads are limited to 256 bytes.
+
+## Version history
+
+| Version | Transport | Notes |
+|---------|-----------|-------|
+| 1       | Plain TCP | Legacy implementation without encryption or timeouts. |
+| 2       | TLS/TCP   | Adds TLS encapsulation, timeouts, and stricter message bounds. |
+
+## Envelope
+
+Each message is composed of a 3-byte header followed by a payload:
+
+| Field | Size (bytes) | Description |
+|-------|--------------|-------------|
+| Type  | 1            | `KolibriNetMessageType` value. |
+| Length| 2            | Payload size in bytes, big-endian. |
+| Payload | variable (≤256) | Encoded message body. |
+
+Messages exceeding the declared limits are rejected.
+
+## Schemas
+
+* **HELLO (`KOLIBRI_MSG_HELLO`, type = 1)**
+  * Payload: 4-byte unsigned integer (`node_id`, big-endian).
+
+* **MIGRATE_RULE (`KOLIBRI_MSG_MIGRATE_RULE`, type = 2)**
+  * Payload layout:
+    1. `node_id` – 4-byte unsigned integer (big-endian).
+    2. `length` – 1 byte, number of digits (≤32).
+    3. `digits` – raw digit bytes (`length` bytes).
+    4. `fitness` – IEEE-754 double encoded as 8-byte unsigned integer in
+       network byte order.
+
+* **ACK (`KOLIBRI_MSG_ACK`, type = 3)**
+  * Payload: 1 byte status code.
+
+Protocol consumers should validate payload sizes before decoding fields.


### PR DESCRIPTION
## Summary
- switch Kolibri network sockets to TLS using OpenSSL with autogenerated self-signed certificates
- enforce message size limits and I/O timeouts for send/receive operations
- document the TLS transport version and message schemas in docs/networking.md

## Testing
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68dbd13cb0388323a23fbdce3cedfe8d