### PR TITLE
Add chat feedback capture end-to-end

### DIFF
--- a/core/feedback_store.py
+++ b/core/feedback_store.py
@@ -1,0 +1,105 @@
+"""Feedback persistence helpers used by integration tests and pipelines."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+import json
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional
+
+
+@dataclass(slots=True)
+class FeedbackRecord:
+  """Represents a single feedback entry collected from the UI."""
+
+  conversation_id: str
+  message_id: str
+  rating: str
+  response: str
+  submitted_at: str
+  comment: Optional[str] = None
+
+  def to_training_row(self) -> Dict[str, str]:
+    """Converts the record into a flat dictionary for ML ingestion."""
+
+    row = {
+      "conversation_id": self.conversation_id,
+      "message_id": self.message_id,
+      "rating": self.rating,
+      "response": self.response,
+      "submitted_at": self.submitted_at,
+    }
+    if self.comment:
+      row["comment"] = self.comment
+    return row
+
+
+class FeedbackStore:
+  """File-backed repository storing feedback submissions as JSON."""
+
+  def __init__(self, path: "str | Path") -> None:
+    self.path = Path(path)
+    self.path.parent.mkdir(parents=True, exist_ok=True)
+    if not self.path.exists():
+      self._write([])
+
+  def load(self) -> List[FeedbackRecord]:
+    """Reads all stored feedback records."""
+
+    try:
+      with self.path.open("r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+    except FileNotFoundError:
+      return []
+
+    if not isinstance(payload, list):
+      return []
+
+    records: List[FeedbackRecord] = []
+    for item in payload:
+      if not isinstance(item, dict):
+        continue
+      try:
+        record = FeedbackRecord(
+          conversation_id=str(item["conversation_id"]),
+          message_id=str(item["message_id"]),
+          rating=str(item["rating"]),
+          response=str(item["response"]),
+          submitted_at=str(item["submitted_at"]),
+          comment=str(item["comment"]) if item.get("comment") else None,
+        )
+      except KeyError:
+        continue
+      records.append(record)
+    return records
+
+  def add(self, record: FeedbackRecord) -> None:
+    """Appends a single record to the underlying storage file."""
+
+    records = self.load()
+    records = [existing for existing in records if existing.message_id != record.message_id]
+    records.append(record)
+    self._write(records)
+
+  def extend(self, records: Iterable[FeedbackRecord]) -> None:
+    """Stores multiple records at once, de-duplicating by message id."""
+
+    existing = {record.message_id: record for record in self.load()}
+    for record in records:
+      existing[record.message_id] = record
+    self._write(list(existing.values()))
+
+  def _write(self, records: List[FeedbackRecord]) -> None:
+    payload = [asdict(record) for record in records]
+    with self.path.open("w", encoding="utf-8") as handle:
+      json.dump(payload, handle, ensure_ascii=False, indent=2, sort_keys=True)
+
+
+def load_feedback_dataset(path: "str | Path") -> Dict[str, List[Dict[str, str]]]:
+  """Loads feedback grouped by conversation for training pipelines."""
+
+  store = FeedbackStore(path)
+  grouped: Dict[str, List[Dict[str, str]]] = {}
+  for record in store.load():
+    grouped.setdefault(record.conversation_id, []).append(record.to_training_row())
+  return grouped

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,8 +4,18 @@ import Sidebar from "./components/Sidebar";
 import WelcomeScreen from "./components/WelcomeScreen";
 import ChatInput from "./components/ChatInput";
 import ChatView from "./components/ChatView";
-import type { ChatMessage } from "./types/chat";
+import type { ChatMessage, FeedbackRating } from "./types/chat";
 import kolibriBridge from "./core/kolibri-bridge";
+import { submitFeedback, type FeedbackSubmission } from "./core/feedback-client";
+
+const STORAGE_KEY = "kolibri.chat.history";
+const generateConversationId = (): string => {
+  const cryptoObj = globalThis.crypto as Crypto | undefined;
+  if (cryptoObj && typeof cryptoObj.randomUUID === "function") {
+    return cryptoObj.randomUUID();
+  }
+  return `conv-${Math.random().toString(36).slice(2)}`;
+};
 
 const App = () => {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
@@ -13,6 +23,37 @@ const App = () => {
   const [mode, setMode] = useState("Быстрый ответ");
   const [isProcessing, setIsProcessing] = useState(false);
   const [bridgeReady, setBridgeReady] = useState(false);
+  const [conversationId, setConversationId] = useState(generateConversationId);
+
+  useEffect(() => {
+    try {
+      const raw = window.localStorage.getItem(STORAGE_KEY);
+      if (!raw) {
+        return;
+      }
+      const parsed = JSON.parse(raw) as { conversationId?: string; messages?: ChatMessage[] };
+      const storedConversationId = parsed.conversationId ?? generateConversationId();
+      if (Array.isArray(parsed.messages) && parsed.messages.length) {
+        const normalisedMessages = parsed.messages.map((message) => ({
+          ...message,
+          conversationId: message.conversationId ?? storedConversationId,
+        }));
+        setMessages(normalisedMessages);
+      }
+      setConversationId(storedConversationId);
+    } catch (error) {
+      console.warn("Не удалось загрузить историю чата из localStorage", error);
+    }
+  }, []);
+
+  useEffect(() => {
+    try {
+      const payload = JSON.stringify({ conversationId, messages });
+      window.localStorage.setItem(STORAGE_KEY, payload);
+    } catch (error) {
+      console.warn("Не удалось сохранить историю чата", error);
+    }
+  }, [conversationId, messages]);
 
   useEffect(() => {
     let cancelled = false;
@@ -34,6 +75,7 @@ const App = () => {
               ? `Не удалось инициализировать KolibriScript: ${error.message}`
               : "Не удалось инициализировать KolibriScript.",
           timestamp: new Date().toLocaleTimeString("ru-RU", { hour: "2-digit", minute: "2-digit" }),
+          conversationId,
         };
         setMessages((prev) => [...prev, assistantMessage]);
       });
@@ -41,7 +83,7 @@ const App = () => {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [conversationId]);
 
   const handleSuggestionSelect = useCallback((prompt: string) => {
     setDraft(prompt);
@@ -52,6 +94,7 @@ const App = () => {
       setMessages([]);
       setDraft("");
       setIsProcessing(false);
+      setConversationId(generateConversationId());
       return;
     }
 
@@ -60,6 +103,7 @@ const App = () => {
         await kolibriBridge.reset();
         setMessages([]);
         setDraft("");
+        setConversationId(generateConversationId());
       } catch (error) {
         const assistantMessage: ChatMessage = {
           id: crypto.randomUUID(),
@@ -69,13 +113,14 @@ const App = () => {
               ? `Не удалось сбросить KolibriScript: ${error.message}`
               : "Не удалось сбросить KolibriScript.",
           timestamp: new Date().toLocaleTimeString("ru-RU", { hour: "2-digit", minute: "2-digit" }),
+          conversationId,
         };
         setMessages((prev) => [...prev, assistantMessage]);
       } finally {
         setIsProcessing(false);
       }
     })();
-  }, [bridgeReady]);
+  }, [bridgeReady, conversationId]);
 
   const sendMessage = useCallback(async () => {
     const content = draft.trim();
@@ -88,6 +133,7 @@ const App = () => {
       role: "user",
       content,
       timestamp: new Date().toLocaleTimeString("ru-RU", { hour: "2-digit", minute: "2-digit" }),
+      conversationId,
     };
 
     setMessages((prev) => [...prev, userMessage]);
@@ -101,6 +147,7 @@ const App = () => {
         role: "assistant",
         content: answer,
         timestamp: new Date().toLocaleTimeString("ru-RU", { hour: "2-digit", minute: "2-digit" }),
+        conversationId,
       };
       setMessages((prev) => [...prev, assistantMessage]);
     } catch (error) {
@@ -112,20 +159,65 @@ const App = () => {
             ? `Не удалось получить ответ: ${error.message}`
             : "Не удалось получить ответ от ядра Колибри.",
         timestamp: new Date().toLocaleTimeString("ru-RU", { hour: "2-digit", minute: "2-digit" }),
+        conversationId,
       };
       setMessages((prev) => [...prev, assistantMessage]);
     } finally {
       setIsProcessing(false);
     }
-  }, [bridgeReady, draft, isProcessing, mode]);
+  }, [bridgeReady, conversationId, draft, isProcessing, mode]);
+
+  const handleFeedbackSubmit = useCallback(
+    (messageId: string, rating: FeedbackRating, comment?: string) => {
+      const submittedAt = new Date().toISOString();
+      const trimmedComment = comment?.trim() ? comment.trim() : undefined;
+      let record: FeedbackSubmission | null = null;
+
+      setMessages((prev) =>
+        prev.map((message) => {
+          if (message.id !== messageId) {
+            return message;
+          }
+          const nextMessage: ChatMessage = {
+            ...message,
+            feedback: {
+              rating,
+              comment: trimmedComment,
+              submittedAt,
+            },
+          };
+          record = {
+            conversationId,
+            messageId,
+            rating,
+            comment: trimmedComment,
+            response: nextMessage.content,
+            submittedAt,
+          };
+          return nextMessage;
+        }),
+      );
+
+      if (record) {
+        void submitFeedback(record);
+      }
+    },
+    [conversationId],
+  );
 
   const content = useMemo(() => {
     if (!messages.length) {
       return <WelcomeScreen onSuggestionSelect={handleSuggestionSelect} />;
     }
 
-    return <ChatView messages={messages} isLoading={isProcessing} />;
-  }, [handleSuggestionSelect, isProcessing, messages]);
+    return (
+      <ChatView
+        messages={messages}
+        isLoading={isProcessing}
+        onFeedbackSubmit={handleFeedbackSubmit}
+      />
+    );
+  }, [handleFeedbackSubmit, handleSuggestionSelect, isProcessing, messages]);
 
   return (
     <Layout sidebar={<Sidebar />}>

--- a/frontend/src/components/ChatMessage.tsx
+++ b/frontend/src/components/ChatMessage.tsx
@@ -1,11 +1,56 @@
-import type { ChatMessage as ChatMessageModel } from "../types/chat";
+import { useEffect, useMemo, useState } from "react";
+import { ThumbsDown, ThumbsUp } from "lucide-react";
+import type { ChatMessage as ChatMessageModel, FeedbackRating } from "../types/chat";
 
 interface ChatMessageProps {
   message: ChatMessageModel;
+  onFeedbackSubmit?: (rating: FeedbackRating, comment?: string) => void;
 }
 
-const ChatMessage = ({ message }: ChatMessageProps) => {
+const formatFeedbackLabel = (rating: FeedbackRating) =>
+  rating === "up" ? "Ответ помог" : "Ответ не помог";
+
+const ChatMessage = ({ message, onFeedbackSubmit }: ChatMessageProps) => {
   const isUser = message.role === "user";
+  const [rating, setRating] = useState<FeedbackRating | null>(message.feedback?.rating ?? null);
+  const [comment, setComment] = useState(message.feedback?.comment ?? "");
+  const [isEditing, setIsEditing] = useState(!message.feedback);
+
+  useEffect(() => {
+    setRating(message.feedback?.rating ?? null);
+    setComment(message.feedback?.comment ?? "");
+    setIsEditing(!message.feedback);
+  }, [message.feedback]);
+
+  const timestamp = useMemo(() => {
+    if (!message.feedback?.submittedAt) {
+      return null;
+    }
+    try {
+      return new Date(message.feedback.submittedAt).toLocaleString("ru-RU", {
+        hour: "2-digit",
+        minute: "2-digit",
+        day: "2-digit",
+        month: "2-digit",
+      });
+    } catch (error) {
+      void error;
+      return message.feedback.submittedAt;
+    }
+  }, [message.feedback?.submittedAt]);
+
+  const handleRating = (nextRating: FeedbackRating) => {
+    setRating(nextRating);
+    setIsEditing(true);
+  };
+
+  const handleSubmit = () => {
+    if (!rating) {
+      return;
+    }
+    onFeedbackSubmit?.(rating, comment.trim() ? comment.trim() : undefined);
+    setIsEditing(false);
+  };
 
   return (
     <div className="flex items-start gap-3">
@@ -16,9 +61,109 @@ const ChatMessage = ({ message }: ChatMessageProps) => {
       >
         {isUser ? "Я" : "К"}
       </div>
-      <div className="rounded-2xl bg-white/80 p-4 shadow-card">
+      <div className="w-full rounded-2xl bg-white/80 p-4 shadow-card">
         <p className="whitespace-pre-line text-sm leading-relaxed text-text-dark">{message.content}</p>
         <p className="mt-2 text-xs text-text-light">{message.timestamp}</p>
+
+        {onFeedbackSubmit && !isUser && (
+          <div className="mt-4 border-t border-surface/60 pt-3">
+            <p className="text-xs font-medium uppercase tracking-wide text-text-light">Оцените ответ</p>
+
+            <div className="mt-2 flex items-center gap-3">
+              <button
+                type="button"
+                onClick={() => handleRating("up")}
+                className={`flex items-center gap-1 rounded-full border px-3 py-1 text-xs transition-colors ${
+                  rating === "up"
+                    ? "border-primary bg-primary/10 text-primary"
+                    : "border-surface text-text-light hover:border-primary/40 hover:text-primary"
+                }`}
+              >
+                <ThumbsUp className="h-4 w-4" />
+                Нравится
+              </button>
+              <button
+                type="button"
+                onClick={() => handleRating("down")}
+                className={`flex items-center gap-1 rounded-full border px-3 py-1 text-xs transition-colors ${
+                  rating === "down"
+                    ? "border-accent-coral bg-accent-coral/10 text-accent-coral"
+                    : "border-surface text-text-light hover:border-accent-coral/40 hover:text-accent-coral"
+                }`}
+              >
+                <ThumbsDown className="h-4 w-4" />
+                Не помогло
+              </button>
+            </div>
+
+            {rating && isEditing && (
+              <div className="mt-3 space-y-2">
+                <label className="block text-xs font-medium text-text-light" htmlFor={`feedback-${message.id}`}>
+                  Комментарий (необязательно)
+                </label>
+                <textarea
+                  id={`feedback-${message.id}`}
+                  className="w-full resize-none rounded-xl border border-surface bg-white/70 p-2 text-sm text-text-dark outline-none transition focus:border-primary focus:ring-1 focus:ring-primary/40"
+                  rows={3}
+                  value={comment}
+                  onChange={(event) => setComment(event.target.value)}
+                  placeholder="Поделитесь, что понравилось или что можно улучшить"
+                />
+                <div className="flex justify-end gap-2">
+                  {message.feedback && (
+                    <button
+                      type="button"
+                      className="rounded-full border border-surface px-3 py-1 text-xs text-text-light hover:border-primary/30 hover:text-primary"
+                      onClick={() => {
+                        setIsEditing(false);
+                        setComment(message.feedback?.comment ?? "");
+                        setRating(message.feedback?.rating ?? rating);
+                      }}
+                    >
+                      Отмена
+                    </button>
+                  )}
+                  <button
+                    type="button"
+                    onClick={handleSubmit}
+                    disabled={!rating}
+                    className="rounded-full bg-primary px-4 py-1 text-xs font-semibold text-white shadow hover:bg-primary/90 disabled:cursor-not-allowed disabled:bg-primary/40"
+                  >
+                    Отправить отзыв
+                  </button>
+                </div>
+              </div>
+            )}
+
+            {message.feedback && !isEditing && (
+              <div className="mt-3 rounded-xl border border-surface/80 bg-white/60 p-3">
+                <div className="flex items-center gap-2 text-xs font-medium text-text-light">
+                  {message.feedback.rating === "up" ? (
+                    <ThumbsUp className="h-4 w-4 text-primary" />
+                  ) : (
+                    <ThumbsDown className="h-4 w-4 text-accent-coral" />
+                  )}
+                  <span>{formatFeedbackLabel(message.feedback.rating)}</span>
+                  {timestamp && <span className="text-[11px] text-text-light/80">{timestamp}</span>}
+                </div>
+                {message.feedback.comment && (
+                  <p className="mt-2 text-sm text-text-dark/80">{message.feedback.comment}</p>
+                )}
+                <button
+                  type="button"
+                  className="mt-3 text-xs font-medium text-primary hover:underline"
+                  onClick={() => {
+                    setIsEditing(true);
+                    setRating(message.feedback?.rating ?? rating);
+                    setComment(message.feedback?.comment ?? "");
+                  }}
+                >
+                  Изменить отзыв
+                </button>
+              </div>
+            )}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/components/ChatView.tsx
+++ b/frontend/src/components/ChatView.tsx
@@ -1,13 +1,14 @@
 import { useEffect, useRef } from "react";
-import type { ChatMessage } from "../types/chat";
+import type { ChatMessage, FeedbackRating } from "../types/chat";
 import ChatMessageView from "./ChatMessage";
 
 interface ChatViewProps {
   messages: ChatMessage[];
   isLoading: boolean;
+  onFeedbackSubmit?: (messageId: string, rating: FeedbackRating, comment?: string) => void;
 }
 
-const ChatView = ({ messages, isLoading }: ChatViewProps) => {
+const ChatView = ({ messages, isLoading, onFeedbackSubmit }: ChatViewProps) => {
   const containerRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
@@ -24,7 +25,15 @@ const ChatView = ({ messages, isLoading }: ChatViewProps) => {
     <section className="flex h-full flex-col rounded-3xl bg-white/70 p-8 shadow-card">
       <div className="flex-1 space-y-6 overflow-y-auto pr-2" ref={containerRef}>
         {messages.map((message) => (
-          <ChatMessageView key={message.id} message={message} />
+          <ChatMessageView
+            key={message.id}
+            message={message}
+            onFeedbackSubmit={
+              message.role === "assistant"
+                ? (rating, comment) => onFeedbackSubmit?.(message.id, rating, comment)
+                : undefined
+            }
+          />
         ))}
         {isLoading && (
           <div className="flex items-center gap-3 text-sm text-text-light">

--- a/frontend/src/core/feedback-client.ts
+++ b/frontend/src/core/feedback-client.ts
@@ -1,0 +1,67 @@
+import type { FeedbackRating } from "../types/chat";
+
+const STORAGE_KEY = "kolibri.chat.feedback";
+
+export interface FeedbackSubmission {
+  conversationId: string;
+  messageId: string;
+  rating: FeedbackRating;
+  comment?: string;
+  response: string;
+  submittedAt: string;
+}
+
+const loadStoredFeedback = (): FeedbackSubmission[] => {
+  if (typeof window === "undefined") {
+    return [];
+  }
+
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+      return [];
+    }
+    const parsed = JSON.parse(raw) as FeedbackSubmission[];
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+    return parsed.filter((entry) => Boolean(entry?.messageId && entry?.rating));
+  } catch (error) {
+    console.warn("Не удалось прочитать сохранённые отзывы", error);
+    return [];
+  }
+};
+
+const persistStoredFeedback = (entries: FeedbackSubmission[]) => {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(entries));
+  } catch (error) {
+    console.warn("Не удалось сохранить отзывы", error);
+  }
+};
+
+export const submitFeedback = async (record: FeedbackSubmission): Promise<void> => {
+  const existing = loadStoredFeedback();
+  const next = existing.filter((entry) => entry.messageId !== record.messageId);
+  next.push(record);
+  persistStoredFeedback(next);
+
+  try {
+    await fetch("/api/feedback", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(record),
+      keepalive: true,
+    });
+  } catch (error) {
+    console.warn("Не удалось отправить отзыв на сервер", error);
+  }
+};
+
+export const getStoredFeedback = (): FeedbackSubmission[] => loadStoredFeedback();

--- a/frontend/src/types/chat.ts
+++ b/frontend/src/types/chat.ts
@@ -1,8 +1,18 @@
 export type ChatRole = "user" | "assistant";
 
+export type FeedbackRating = "up" | "down";
+
+export interface ChatFeedback {
+  rating: FeedbackRating;
+  comment?: string;
+  submittedAt: string;
+}
+
 export interface ChatMessage {
   id: string;
   role: ChatRole;
   content: string;
   timestamp: string;
+  conversationId: string;
+  feedback?: ChatFeedback;
 }

--- a/scripts/feedback_server.py
+++ b/scripts/feedback_server.py
@@ -1,0 +1,84 @@
+"""Minimal HTTP server that stores chat feedback submissions on disk."""
+
+from __future__ import annotations
+
+import json
+import os
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+from typing import Tuple
+
+from core.feedback_store import FeedbackRecord, FeedbackStore
+
+DEFAULT_PORT = 8787
+STORE_PATH = Path(os.getenv("KOLIBRI_FEEDBACK_PATH", "logs/feedback.json"))
+
+
+class FeedbackRequestHandler(BaseHTTPRequestHandler):
+  store = FeedbackStore(STORE_PATH)
+
+  def do_POST(self) -> None:  # noqa: N802  (BaseHTTPRequestHandler API)
+    if self.path != "/api/feedback":
+      self.send_error(404, "Unknown endpoint")
+      return
+
+    content_length = int(self.headers.get("Content-Length", "0"))
+    payload_bytes = self.rfile.read(content_length)
+
+    try:
+      payload = json.loads(payload_bytes)
+    except json.JSONDecodeError:
+      self.send_error(400, "Body must be valid JSON")
+      return
+
+    try:
+      record = FeedbackRecord(
+        conversation_id=str(payload["conversationId"]),
+        message_id=str(payload["messageId"]),
+        rating=str(payload["rating"]),
+        response=str(payload["response"]),
+        submitted_at=str(payload["submittedAt"]),
+        comment=str(payload.get("comment")) if payload.get("comment") else None,
+      )
+    except KeyError as error:
+      self.send_error(400, f"Missing field: {error.args[0]}")
+      return
+
+    self.store.add(record)
+    self.send_response(204)
+    self.end_headers()
+
+  def do_GET(self) -> None:  # noqa: N802  (BaseHTTPRequestHandler API)
+    if self.path != "/api/feedback":
+      self.send_error(404, "Unknown endpoint")
+      return
+
+    dataset = [record.to_training_row() for record in self.store.load()]
+    body = json.dumps(dataset, ensure_ascii=False).encode("utf-8")
+
+    self.send_response(200)
+    self.send_header("Content-Type", "application/json; charset=utf-8")
+    self.send_header("Content-Length", str(len(body)))
+    self.end_headers()
+    self.wfile.write(body)
+
+  def log_message(self, format: str, *args: Tuple[object, ...]) -> None:  # noqa: A003
+    if os.getenv("KOLIBRI_FEEDBACK_SILENT") == "1":
+      return
+    super().log_message(format, *args)
+
+
+def main() -> None:
+  port = int(os.getenv("KOLIBRI_FEEDBACK_PORT", DEFAULT_PORT))
+  server = HTTPServer(("0.0.0.0", port), FeedbackRequestHandler)
+  print(f"Feedback server listening on http://127.0.0.1:{port}/api/feedback")
+  try:
+    server.serve_forever()
+  except KeyboardInterrupt:
+    pass
+  finally:
+    server.server_close()
+
+
+if __name__ == "__main__":
+  main()

--- a/tests/test_feedback_store.py
+++ b/tests/test_feedback_store.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from core.feedback_store import FeedbackRecord, FeedbackStore, load_feedback_dataset
+
+
+def test_feedback_persists_across_reload(tmp_path: Path) -> None:
+  store_path = tmp_path / "feedback.json"
+  store = FeedbackStore(store_path)
+
+  first = FeedbackRecord(
+    conversation_id="conv-1",
+    message_id="msg-1",
+    rating="up",
+    response="Ответ Колибри",
+    submitted_at="2024-05-30T18:55:00Z",
+    comment="Очень полезно",
+  )
+  store.add(first)
+
+  reloaded = FeedbackStore(store_path)
+  records = reloaded.load()
+  assert records == [first]
+
+
+def test_feedback_dataset_grouping(tmp_path: Path) -> None:
+  store = FeedbackStore(tmp_path / "feedback.json")
+  store.extend(
+    [
+      FeedbackRecord(
+        conversation_id="conv-1",
+        message_id="msg-1",
+        rating="up",
+        response="Первый ответ",
+        submitted_at="2024-05-30T18:55:00Z",
+        comment="👍",
+      ),
+      FeedbackRecord(
+        conversation_id="conv-1",
+        message_id="msg-2",
+        rating="down",
+        response="Второй ответ",
+        submitted_at="2024-05-30T19:05:00Z",
+      ),
+      FeedbackRecord(
+        conversation_id="conv-2",
+        message_id="msg-3",
+        rating="up",
+        response="Третий ответ",
+        submitted_at="2024-05-30T19:15:00Z",
+        comment="нужно уточнение",
+      ),
+    ]
+  )
+
+  dataset = load_feedback_dataset(tmp_path / "feedback.json")
+  assert set(dataset.keys()) == {"conv-1", "conv-2"}
+  assert {row["message_id"] for row in dataset["conv-1"]} == {"msg-1", "msg-2"}
+  assert dataset["conv-2"][0]["comment"] == "нужно уточнение"


### PR DESCRIPTION
## Summary
- add feedback controls to chat messages with persistence across browser reloads
- record submissions via a client helper that writes to local storage and posts to the new feedback endpoint
- provide a JSON-backed feedback store, simple HTTP server, and regression tests that ensure reload-safe ingestion for training pipelines

## Testing
- pytest tests/test_feedback_store.py
- npm --prefix frontend run build

------
https://chatgpt.com/codex/tasks/task_e_68dbd58896a08323b0a5f285461bfe4f