### PR TITLE
Add knowledge search backend and surface context in chat

### DIFF
--- a/backend/knowledge-service/data/knowledge.json
+++ b/backend/knowledge-service/data/knowledge.json
@@ -1,0 +1,20 @@
+[
+  {
+    "id": "readme-overview",
+    "title": "Kolibri OS — обзор платформы",
+    "source": "README.md",
+    "content": "Kolibri OS — легковесная экспериментальная платформа, объединяющая KolibriScript, симулятор и набор утилит для отладки цифровых сценариев. Чтобы запустить окружение разработчика, требуется Python 3.10+, pip, virtualenv и компилятор C/C++ с CMake 3.20+. После подготовки виртуального окружения необходимо установить зависимости из requirements.txt, собрать C-компоненты через cmake -S . -B build и cmake --build build, а также собрать wasm-ядро скриптом scripts/build_wasm.sh перед сборкой фронтенда." 
+  },
+  {
+    "id": "readme-quality-checks",
+    "title": "Проверки качества Kolibri OS",
+    "source": "README.md",
+    "content": "Для проверки качества проекта предусмотрены линтеры Python (ruff check, pyright), политики проекта (python scripts/policy_validate.py) и сборка тестов ctest --test-dir build. Фронтенд собирается через npm run build после установки npm-зависимостей." 
+  },
+  {
+    "id": "docs-integrated-prototype",
+    "title": "Kolibri Integrated Prototype — архитектура",
+    "source": "docs/kolibri_integrated_prototype.md",
+    "content": "Документ Kolibri Integrated Prototype описывает эволюцию Kolibri AI от фрактальной десятичной логики к экспериментам с C/WASM ядром и PWA-интерфейсом. Он выделяет Kolibri Chain как микроблокчейн для обмена знаниями, кластерные узлы для синхронизации знаний и план развития до масштабирования кластеров до 128 узлов к 2026 году." 
+  }
+]

--- a/backend/knowledge-service/package.json
+++ b/backend/knowledge-service/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "knowledge-service",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Lightweight knowledge search API for Kolibri OS UI",
+  "license": "MIT",
+  "main": "src/server.js",
+  "type": "commonjs",
+  "scripts": {
+    "start": "node src/server.js"
+  },
+  "dependencies": {
+    "cors": "^2.8.5",
+    "express": "^4.19.2"
+  }
+}

--- a/backend/knowledge-service/src/server.js
+++ b/backend/knowledge-service/src/server.js
@@ -1,0 +1,155 @@
+const express = require("express");
+const cors = require("cors");
+const fs = require("fs");
+const path = require("path");
+
+const app = express();
+const PORT = process.env.PORT || 4000;
+
+app.use(cors());
+app.use(express.json());
+
+const knowledgePath = path.join(__dirname, "..", "data", "knowledge.json");
+let knowledgeBase = [];
+
+function loadKnowledge() {
+  try {
+    const raw = fs.readFileSync(knowledgePath, "utf-8");
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed)) {
+      knowledgeBase = parsed;
+    } else {
+      console.warn("Knowledge base file does not contain an array. Using empty base.");
+      knowledgeBase = [];
+    }
+  } catch (error) {
+    console.error("Failed to load knowledge base:", error);
+    knowledgeBase = [];
+  }
+}
+
+function normaliseToken(token) {
+  return token
+    .toLowerCase()
+    .replace(/["'`.,!?;:()\[\]{}<>]+/g, "")
+    .trim();
+}
+
+function tokenize(text) {
+  if (!text) {
+    return [];
+  }
+  return text
+    .split(/\s+/)
+    .map(normaliseToken)
+    .filter((token) => token.length > 0);
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function computeScore(tokens, text) {
+  if (!tokens.length) {
+    return 0;
+  }
+
+  const haystack = text.toLowerCase();
+  let score = 0;
+
+  for (const token of tokens) {
+    if (!token) {
+      continue;
+    }
+    const matcher = new RegExp(escapeRegExp(token), "g");
+    const matches = haystack.match(matcher);
+    if (matches && matches.length > 0) {
+      score += 1 + matches.length * 0.05;
+    }
+  }
+
+  return Number(score.toFixed(4));
+}
+
+function createSnippet(content, tokens, maxLength = 240) {
+  const cleanContent = content.replace(/\s+/g, " ").trim();
+  if (cleanContent.length <= maxLength) {
+    return cleanContent;
+  }
+
+  const lowerContent = cleanContent.toLowerCase();
+  let bestIndex = 0;
+
+  for (const token of tokens) {
+    if (!token) {
+      continue;
+    }
+    const index = lowerContent.indexOf(token);
+    if (index !== -1) {
+      bestIndex = index;
+      break;
+    }
+  }
+
+  const start = Math.max(0, bestIndex - Math.floor(maxLength / 2));
+  const end = Math.min(cleanContent.length, start + maxLength);
+  let snippet = cleanContent.slice(start, end).trim();
+
+  if (start > 0) {
+    snippet = `…${snippet}`;
+  }
+  if (end < cleanContent.length) {
+    snippet = `${snippet}…`;
+  }
+
+  return snippet;
+}
+
+app.get("/knowledge/search", (req, res) => {
+  const query = (req.query.q || req.query.query || "").toString().trim();
+  const limit = Math.max(1, Math.min(10, Number.parseInt(req.query.limit, 10) || 3));
+
+  if (!query) {
+    return res.json({ query: "", documents: [] });
+  }
+
+  const tokens = Array.from(new Set(tokenize(query)));
+  const ranked = knowledgeBase
+    .map((doc) => {
+      const combined = `${doc.title}\n${doc.content}`;
+      const score = computeScore(tokens, combined);
+      return {
+        score,
+        document: doc,
+      };
+    })
+    .filter((entry) => entry.score > 0)
+    .sort((a, b) => {
+      if (b.score !== a.score) {
+        return b.score - a.score;
+      }
+      return a.document.title.localeCompare(b.document.title, "ru");
+    })
+    .slice(0, limit)
+    .map((entry) => ({
+      id: entry.document.id,
+      title: entry.document.title,
+      source: entry.document.source,
+      content: entry.document.content,
+      snippet: createSnippet(entry.document.content, tokens),
+      score: entry.score,
+    }));
+
+  res.json({ query, documents: ranked });
+});
+
+app.get("/health", (_req, res) => {
+  res.json({ status: "ok", documents: knowledgeBase.length });
+});
+
+loadKnowledge();
+
+app.listen(PORT, () => {
+  console.log(`Knowledge service listening on port ${PORT}`);
+});
+

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,6 +6,8 @@ import ChatInput from "./components/ChatInput";
 import ChatView from "./components/ChatView";
 import type { ChatMessage } from "./types/chat";
 import kolibriBridge from "./core/kolibri-bridge";
+import ContextPanel from "./components/ContextPanel";
+import type { KnowledgeDocument, KnowledgeSearchResponse } from "./types/knowledge";
 
 const App = () => {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
@@ -13,6 +15,10 @@ const App = () => {
   const [mode, setMode] = useState("Быстрый ответ");
   const [isProcessing, setIsProcessing] = useState(false);
   const [bridgeReady, setBridgeReady] = useState(false);
+  const [contextDocuments, setContextDocuments] = useState<KnowledgeDocument[]>([]);
+  const [contextQuery, setContextQuery] = useState<string | null>(null);
+  const [contextError, setContextError] = useState<string | null>(null);
+  const [isContextLoading, setIsContextLoading] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -52,6 +58,10 @@ const App = () => {
       setMessages([]);
       setDraft("");
       setIsProcessing(false);
+      setContextDocuments([]);
+      setContextQuery(null);
+      setContextError(null);
+      setIsContextLoading(false);
       return;
     }
 
@@ -60,6 +70,9 @@ const App = () => {
         await kolibriBridge.reset();
         setMessages([]);
         setDraft("");
+        setContextDocuments([]);
+        setContextQuery(null);
+        setContextError(null);
       } catch (error) {
         const assistantMessage: ChatMessage = {
           id: crypto.randomUUID(),
@@ -73,6 +86,7 @@ const App = () => {
         setMessages((prev) => [...prev, assistantMessage]);
       } finally {
         setIsProcessing(false);
+        setIsContextLoading(false);
       }
     })();
   }, [bridgeReady]);
@@ -95,7 +109,49 @@ const App = () => {
     setIsProcessing(true);
 
     try {
-      const answer = await kolibriBridge.ask(content, mode);
+      setContextQuery(content);
+      setIsContextLoading(true);
+      setContextError(null);
+      setContextDocuments([]);
+      let retrievedDocuments: KnowledgeDocument[] = [];
+
+      try {
+        const response = await fetch(
+          `/knowledge/search?q=${encodeURIComponent(content)}&limit=3`
+        );
+        if (!response.ok) {
+          throw new Error(`HTTP ${response.status}`);
+        }
+        const data = (await response.json()) as KnowledgeSearchResponse;
+        if (data && Array.isArray(data.documents)) {
+          retrievedDocuments = data.documents;
+        } else {
+          throw new Error("Некорректный ответ сервиса знаний");
+        }
+      } catch (error) {
+        if (error instanceof Error) {
+          setContextError(`Не удалось получить контекст: ${error.message}`);
+        } else {
+          setContextError("Не удалось получить контекст: неизвестная ошибка");
+        }
+        retrievedDocuments = [];
+      } finally {
+        setIsContextLoading(false);
+        setContextDocuments(retrievedDocuments);
+      }
+
+      let prompt = content;
+      if (retrievedDocuments.length > 0) {
+        const contextBlock = retrievedDocuments
+          .map(
+            (doc, index) =>
+              `Источник ${index + 1}: ${doc.title}\n${doc.content}`
+          )
+          .join("\n\n");
+        prompt = `Используй предоставленные документы Kolibri при формировании ответа. Если информации недостаточно, сообщи об этом.\n${contextBlock}\n\nВопрос пользователя: ${content}`;
+      }
+
+      const answer = await kolibriBridge.ask(prompt, mode);
       const assistantMessage: ChatMessage = {
         id: crypto.randomUUID(),
         role: "assistant",
@@ -119,7 +175,7 @@ const App = () => {
     }
   }, [bridgeReady, draft, isProcessing, mode]);
 
-  const content = useMemo(() => {
+  const conversationContent = useMemo(() => {
     if (!messages.length) {
       return <WelcomeScreen onSuggestionSelect={handleSuggestionSelect} />;
     }
@@ -129,7 +185,13 @@ const App = () => {
 
   return (
     <Layout sidebar={<Sidebar />}>
-      <div className="flex-1">{content}</div>
+      <ContextPanel
+        query={contextQuery}
+        documents={contextDocuments}
+        isLoading={isContextLoading}
+        error={contextError}
+      />
+      <div className="flex-1">{conversationContent}</div>
       <ChatInput
         value={draft}
         mode={mode}

--- a/frontend/src/components/ContextPanel.tsx
+++ b/frontend/src/components/ContextPanel.tsx
@@ -1,0 +1,67 @@
+import { AlertCircle, BookOpen, Loader2 } from "lucide-react";
+import type { KnowledgeDocument } from "../types/knowledge";
+
+interface ContextPanelProps {
+  query?: string | null;
+  documents: KnowledgeDocument[];
+  isLoading: boolean;
+  error?: string | null;
+}
+
+const ContextPanel = ({ query, documents, isLoading, error }: ContextPanelProps) => {
+  const hasContext = documents.length > 0;
+  const shouldRender = hasContext || isLoading || Boolean(error);
+
+  if (!shouldRender) {
+    return null;
+  }
+
+  return (
+    <section className="rounded-3xl bg-white/70 p-6 shadow-card">
+      <header className="mb-4 flex items-center justify-between gap-3">
+        <div className="flex items-center gap-3 text-primary">
+          <div className="flex h-10 w-10 items-center justify-center rounded-2xl bg-primary/10">
+            <BookOpen className="h-5 w-5" />
+          </div>
+          <div>
+            <p className="text-sm font-semibold text-text-dark">Контекст памяти</p>
+            {query && <p className="text-xs text-text-light">Запрос: “{query}”</p>}
+          </div>
+        </div>
+        {isLoading && (
+          <div className="flex items-center gap-2 text-xs text-text-light">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            Обновление…
+          </div>
+        )}
+      </header>
+
+      {error && (
+        <div className="mb-4 flex items-start gap-2 rounded-2xl bg-red-100/80 p-3 text-xs text-red-600">
+          <AlertCircle className="mt-0.5 h-4 w-4" />
+          <span>{error}</span>
+        </div>
+      )}
+
+      {hasContext ? (
+        <ul className="space-y-3">
+          {documents.map((doc) => (
+            <li key={doc.id} className="rounded-2xl bg-background-light/60 p-4">
+              <p className="text-sm font-semibold text-text-dark">{doc.title}</p>
+              <p className="mt-1 text-xs text-text-light">{doc.snippet}</p>
+              {doc.source && (
+                <p className="mt-2 text-[11px] uppercase tracking-wide text-text-light/80">
+                  Источник: {doc.source}
+                </p>
+              )}
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p className="text-sm text-text-light">Релевантный контекст не найден.</p>
+      )}
+    </section>
+  );
+};
+
+export default ContextPanel;

--- a/frontend/src/types/knowledge.ts
+++ b/frontend/src/types/knowledge.ts
@@ -1,0 +1,13 @@
+export interface KnowledgeDocument {
+  id: string;
+  title: string;
+  content: string;
+  snippet: string;
+  score: number;
+  source?: string;
+}
+
+export interface KnowledgeSearchResponse {
+  query: string;
+  documents: KnowledgeDocument[];
+}


### PR DESCRIPTION
## Summary
- add an Express-based knowledge service with a /knowledge/search endpoint and seeded Kolibri docs
- request relevant knowledge before invoking KolibriScript and embed the retrieved context into prompts
- show a context panel in the UI that reflects loaded documents and fetch status

## Testing
- npm --prefix frontend run lint

------
https://chatgpt.com/codex/tasks/task_e_68dbd0ed79f88323941332304a8d484a