### PR TITLE
Add SSE streaming endpoint and frontend streaming client

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -1,0 +1,122 @@
+"""Минимальный HTTP-сервер Kolibri, отдающий ответы через SSE."""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Iterable, Iterator
+
+_STREAM_ENDPOINT = "/api/chat/stream"
+_DEFAULT_MODE = "Быстрый ответ"
+
+
+def _build_response(prompt: str, mode: str) -> str:
+    prompt = prompt.strip()
+    if not prompt:
+        return "KolibriScript завершил работу без вывода."
+    mode = mode.strip() or _DEFAULT_MODE
+    return f"[{mode}] Колибри получил запрос: {prompt}"
+
+
+def _stream_tokens(text: str, chunk_size: int = 16) -> Iterator[str]:
+    for index in range(0, len(text), chunk_size):
+        yield text[index : index + chunk_size]
+        time.sleep(0.05)
+
+
+class KolibriSSEHandler(BaseHTTPRequestHandler):
+    server_version = "KolibriSSE/0.1"
+
+    def log_message(self, format: str, *args: object) -> None:  # noqa: A003 - наследуем API BaseHTTPRequestHandler
+        return
+
+    def end_headers(self) -> None:
+        self.send_header("Access-Control-Allow-Origin", "*")
+        super().end_headers()
+
+    def do_OPTIONS(self) -> None:  # noqa: N802 - часть HTTP API
+        if self.path != _STREAM_ENDPOINT:
+            self.send_error(HTTPStatus.NOT_FOUND)
+            return
+        self.send_response(HTTPStatus.NO_CONTENT)
+        self.send_header("Access-Control-Allow-Methods", "POST, OPTIONS")
+        self.send_header("Access-Control-Allow-Headers", "Content-Type")
+        self.end_headers()
+
+    def do_POST(self) -> None:  # noqa: N802 - часть HTTP API
+        if self.path != _STREAM_ENDPOINT:
+            self.send_error(HTTPStatus.NOT_FOUND)
+            return
+
+        length_header = self.headers.get("Content-Length")
+        if not length_header:
+            self.send_error(HTTPStatus.LENGTH_REQUIRED, "Отсутствует длина запроса")
+            return
+
+        try:
+            body = self.rfile.read(int(length_header))
+        except ValueError:
+            self.send_error(HTTPStatus.BAD_REQUEST, "Некорректная длина запроса")
+            return
+
+        try:
+            payload = json.loads(body.decode("utf-8"))
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            self.send_error(HTTPStatus.BAD_REQUEST, "Некорректный JSON")
+            return
+
+        prompt = str(payload.get("prompt", ""))
+        mode = str(payload.get("mode", _DEFAULT_MODE))
+        response_text = _build_response(prompt, mode)
+
+        self.send_response(HTTPStatus.OK)
+        self.send_header("Content-Type", "text/event-stream; charset=utf-8")
+        self.send_header("Cache-Control", "no-cache")
+        self.send_header("Connection", "keep-alive")
+        self.send_header("X-Accel-Buffering", "no")
+        self.end_headers()
+
+        generator: Iterable[str] = _stream_tokens(response_text)
+        try:
+            for token in generator:
+                chunk = f"data: {token}\n\n".encode("utf-8")
+                self.wfile.write(chunk)
+                self.wfile.flush()
+        except (BrokenPipeError, ConnectionResetError, ConnectionAbortedError):
+            return
+        finally:
+            if hasattr(generator, "close"):
+                try:
+                    generator.close()  # type: ignore[attr-defined]
+                except Exception:
+                    pass
+
+        try:
+            self.wfile.write(b"event: done\n\n")
+            self.wfile.flush()
+        except (BrokenPipeError, ConnectionResetError, ConnectionAbortedError):
+            return
+
+
+def run(host: str = "0.0.0.0", port: int = 8080) -> ThreadingHTTPServer:
+    server = ThreadingHTTPServer((host, port), KolibriSSEHandler)
+
+    thread = threading.Thread(target=server.serve_forever, name="kolibri-sse", daemon=True)
+    thread.start()
+    return server
+
+
+if __name__ == "__main__":
+    httpd = run()
+    try:
+        print(f"Kolibri SSE server запущен на {httpd.server_address}")
+        while True:
+            time.sleep(1)
+    except KeyboardInterrupt:
+        print("Остановка Kolibri SSE сервера...")
+    finally:
+        httpd.shutdown()
+        httpd.server_close()

--- a/frontend/src/api/chatStream.ts
+++ b/frontend/src/api/chatStream.ts
@@ -1,0 +1,113 @@
+export interface StreamChatOptions {
+  prompt: string;
+  mode: string;
+  signal?: AbortSignal;
+  onToken: (token: string) => void;
+  onComplete?: () => void;
+}
+
+const STREAM_ENDPOINT = "/api/chat/stream";
+
+interface ParsedEvent {
+  readonly type: string;
+  readonly data: string;
+}
+
+function parseEvent(rawEvent: string): ParsedEvent | null {
+  if (!rawEvent.trim()) {
+    return null;
+  }
+
+  let eventType = "message";
+  const dataLines: string[] = [];
+
+  for (const line of rawEvent.split("\n")) {
+    const trimmed = line.trimEnd();
+    if (!trimmed) {
+      continue;
+    }
+    if (trimmed.startsWith("event:")) {
+      eventType = trimmed.slice(6).trim() || "message";
+      continue;
+    }
+    if (trimmed.startsWith("data:")) {
+      dataLines.push(trimmed.slice(5).trimStart());
+      continue;
+    }
+  }
+
+  return { type: eventType, data: dataLines.join("\n") };
+}
+
+export async function streamChatCompletion(options: StreamChatOptions): Promise<void> {
+  const response = await fetch(STREAM_ENDPOINT, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ prompt: options.prompt, mode: options.mode }),
+    signal: options.signal,
+  });
+
+  if (!response.ok) {
+    throw new Error(`Сервер вернул статус ${response.status}`);
+  }
+
+  if (!response.body) {
+    throw new Error("Потоковый ответ недоступен");
+  }
+
+  const reader = response.body.pipeThrough(new TextDecoderStream()).getReader();
+  let buffer = "";
+  let doneReceived = false;
+
+  try {
+    let streamClosed = false;
+    while (!streamClosed) {
+      const { value, done } = await reader.read();
+      if (done) {
+        streamClosed = true;
+        continue;
+      }
+      if (value) {
+        buffer += value;
+      }
+
+      let boundaryIndex = buffer.indexOf("\n\n");
+      while (boundaryIndex !== -1) {
+        const rawEvent = buffer.slice(0, boundaryIndex);
+        buffer = buffer.slice(boundaryIndex + 2);
+        boundaryIndex = buffer.indexOf("\n\n");
+
+        const parsed = parseEvent(rawEvent);
+        if (!parsed) {
+          continue;
+        }
+
+        if (parsed.type === "done") {
+          doneReceived = true;
+          options.onComplete?.();
+          return;
+        }
+
+        if (parsed.type === "error") {
+          throw new Error(parsed.data || "Сервер сообщил об ошибке");
+        }
+
+        if (parsed.data) {
+          options.onToken(parsed.data);
+        }
+      }
+    }
+  } finally {
+    try {
+      await reader.cancel();
+    } catch {
+      // Игнорируем ошибки отмены, поток уже завершён.
+    }
+  }
+
+  if (!doneReceived) {
+    options.onComplete?.();
+  }
+}

--- a/frontend/src/components/ChatInput.tsx
+++ b/frontend/src/components/ChatInput.tsx
@@ -1,19 +1,21 @@
-import { Paperclip, Plus, RefreshCw, SendHorizontal } from "lucide-react";
+import { Paperclip, Plus, RefreshCw, SendHorizontal, XCircle } from "lucide-react";
 import { useId } from "react";
 
 interface ChatInputProps {
   value: string;
   mode: string;
   isBusy: boolean;
+  isStreaming: boolean;
   onChange: (value: string) => void;
   onModeChange: (mode: string) => void;
   onSubmit: () => void;
   onReset: () => void;
+  onCancel?: () => void;
 }
 
 const modes = ["Быстрый ответ", "Исследование", "Творческий"];
 
-const ChatInput = ({ value, mode, isBusy, onChange, onModeChange, onSubmit, onReset }: ChatInputProps) => {
+const ChatInput = ({ value, mode, isBusy, isStreaming, onChange, onModeChange, onSubmit, onReset, onCancel }: ChatInputProps) => {
   const textAreaId = useId();
 
   return (
@@ -31,7 +33,7 @@ const ChatInput = ({ value, mode, isBusy, onChange, onModeChange, onSubmit, onRe
             className="rounded-xl border border-transparent bg-background-light/60 px-3 py-2 text-sm font-medium text-text-dark focus:border-primary focus:outline-none"
             value={mode}
             onChange={(event) => onModeChange(event.target.value)}
-            disabled={isBusy}
+            disabled={isBusy || isStreaming}
           >
             {modes.map((item) => (
               <option key={item} value={item}>
@@ -53,7 +55,7 @@ const ChatInput = ({ value, mode, isBusy, onChange, onModeChange, onSubmit, onRe
           <button
             type="button"
             className="flex items-center gap-2 rounded-xl bg-background-light/60 px-3 py-2 text-xs font-semibold text-text-light transition-colors hover:text-text-dark"
-            disabled={isBusy}
+            disabled={isBusy || isStreaming}
           >
             <Paperclip className="h-4 w-4" />
             Вложить
@@ -62,6 +64,7 @@ const ChatInput = ({ value, mode, isBusy, onChange, onModeChange, onSubmit, onRe
             type="button"
             onClick={onReset}
             className="flex items-center gap-2 rounded-xl bg-background-light/60 px-3 py-2 text-xs font-semibold text-text-light transition-colors hover:text-text-dark"
+            disabled={isBusy || isStreaming}
           >
             <Plus className="h-4 w-4" />
             Новый диалог
@@ -72,20 +75,32 @@ const ChatInput = ({ value, mode, isBusy, onChange, onModeChange, onSubmit, onRe
             type="button"
             onClick={onReset}
             className="flex items-center gap-2 rounded-xl bg-background-light/60 px-4 py-2 text-sm font-medium text-text-light transition-colors hover:text-text-dark"
-            disabled={isBusy}
+            disabled={isBusy || isStreaming}
           >
             <RefreshCw className="h-4 w-4" />
             Сбросить
           </button>
-          <button
-            type="button"
-            onClick={onSubmit}
-            className="flex items-center gap-2 rounded-xl bg-primary px-4 py-2 text-sm font-semibold text-white transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
-            disabled={isBusy || !value.trim()}
-          >
-            <SendHorizontal className="h-4 w-4" />
-            Отправить
-          </button>
+          {isStreaming ? (
+            <button
+              type="button"
+              onClick={onCancel}
+              className="flex items-center gap-2 rounded-xl bg-accent-coral px-4 py-2 text-sm font-semibold text-white transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
+              disabled={!onCancel}
+            >
+              <XCircle className="h-4 w-4" />
+              Отменить
+            </button>
+          ) : (
+            <button
+              type="button"
+              onClick={onSubmit}
+              className="flex items-center gap-2 rounded-xl bg-primary px-4 py-2 text-sm font-semibold text-white transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
+              disabled={isBusy || !value.trim()}
+            >
+              <SendHorizontal className="h-4 w-4" />
+              Отправить
+            </button>
+          )}
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add a simple SSE backend endpoint that streams generated tokens while handling cancellation
- introduce a streaming chat client in the frontend with partial-response state management and graceful cleanup
- update the chat input to surface a cancel control and disable conflicting actions during streaming

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dbd0ee8d288323a46be60c231fa488