### PR TITLE
Add attachment upload support

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -1,0 +1,176 @@
+"""REST API Kolibri для загрузки и предобработки вложений."""
+
+from __future__ import annotations
+
+import mimetypes
+import os
+import uuid
+from pathlib import Path
+from typing import Optional, Tuple
+
+from fastapi import FastAPI, File, HTTPException, UploadFile
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import FileResponse
+from pydantic import BaseModel
+
+try:  # PDF может извлекаться, если установлен pypdf.
+    from pypdf import PdfReader  # type: ignore
+except ImportError:  # pragma: no cover - библиотека опциональна на CI.
+    PdfReader = None  # type: ignore[assignment]
+
+MAX_FILE_SIZE = 8 * 1024 * 1024  # 8 MiB
+MAX_TEXT_LENGTH = 20_000
+TEXT_EXTENSIONS = {".txt", ".md", ".markdown", ".csv", ".json", ".log"}
+
+UPLOAD_ROOT = Path(os.getenv("KOLIBRI_UPLOAD_DIR", "logs/uploads")).resolve()
+UPLOAD_ROOT.mkdir(parents=True, exist_ok=True)
+
+app = FastAPI(title="Kolibri Attachments API")
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+class AttachmentProcessingResult(BaseModel):
+    """Ответ API с результатами обработки вложения."""
+
+    attachment_id: str
+    filename: str
+    content_type: str
+    text: Optional[str] = None
+    truncated: bool = False
+    download_url: str
+    ocr_performed: bool = False
+    note: Optional[str] = None
+
+
+@app.post("/api/attachments", response_model=AttachmentProcessingResult)
+async def upload_attachment(file: UploadFile = File(...)) -> AttachmentProcessingResult:
+    """Принимает файл, сохраняет и извлекает текстовое содержимое."""
+
+    if not file.filename:
+        raise HTTPException(status_code=400, detail="Имя файла не указано.")
+
+    safe_name = Path(file.filename).name
+    content_type = file.content_type or mimetypes.guess_type(safe_name)[0] or "application/octet-stream"
+
+    file_id = uuid.uuid4().hex
+    suffix = Path(safe_name).suffix
+    stored_name = f"{file_id}{suffix.lower()}" if suffix else file_id
+    stored_path = UPLOAD_ROOT / stored_name
+
+    size = 0
+    with stored_path.open("wb") as buffer:
+        while True:
+            chunk = await file.read(1024 * 1024)
+            if not chunk:
+                break
+            size += len(chunk)
+            if size > MAX_FILE_SIZE:
+                stored_path.unlink(missing_ok=True)
+                raise HTTPException(status_code=413, detail="Файл превышает максимально допустимый размер 8 МБ.")
+            buffer.write(chunk)
+
+    text, truncated, ocr_performed, note = _extract_text(stored_path, content_type)
+    download_url = f"/attachments/{stored_path.name}"
+
+    return AttachmentProcessingResult(
+        attachment_id=file_id,
+        filename=safe_name,
+        content_type=content_type,
+        text=text,
+        truncated=truncated,
+        download_url=download_url,
+        ocr_performed=ocr_performed,
+        note=note,
+    )
+
+
+@app.get("/attachments/{attachment_name}")
+async def download_attachment(attachment_name: str) -> FileResponse:
+    """Возвращает ранее загруженный файл по безопасному пути."""
+
+    sanitised = Path(attachment_name).name
+    stored_path = UPLOAD_ROOT / sanitised
+    if not stored_path.exists():
+        raise HTTPException(status_code=404, detail="Вложение не найдено.")
+    media_type = mimetypes.guess_type(sanitised)[0] or "application/octet-stream"
+    return FileResponse(stored_path, filename=sanitised, media_type=media_type)
+
+
+def _extract_text(path: Path, content_type: str) -> Tuple[Optional[str], bool, bool, Optional[str]]:
+    """Пытается извлечь текст из файла."""
+
+    suffix = path.suffix.lower()
+    lowered_type = content_type.lower()
+
+    if lowered_type.startswith("text/") or suffix in TEXT_EXTENSIONS:
+        raw = path.read_bytes()
+        text = _decode_bytes(raw).strip()
+        truncated_text, truncated_flag = _truncate(text)
+        return truncated_text, truncated_flag, False, None
+
+    if lowered_type == "application/pdf" or suffix == ".pdf":
+        if PdfReader is None:
+            return None, False, False, "Обработка PDF недоступна: установите пакет 'pypdf'."
+        try:
+            reader = PdfReader(str(path))
+        except Exception as error:  # pragma: no cover - зависит от содержимого PDF.
+            return None, False, False, f"Не удалось прочитать PDF: {error}"
+        chunks = []
+        for page in reader.pages:
+            page_text = page.extract_text() or ""
+            if page_text:
+                chunks.append(page_text)
+        combined = "\n".join(chunks).strip()
+        truncated_text, truncated_flag = _truncate(combined)
+        return truncated_text, truncated_flag, False, None
+
+    if lowered_type.startswith("image/"):
+        try:
+            from PIL import Image  # type: ignore
+            import pytesseract  # type: ignore
+            from pytesseract import TesseractNotFoundError  # type: ignore
+        except ImportError:
+            return None, False, False, "OCR для изображений недоступен: установите 'pillow' и 'pytesseract'."
+
+        try:
+            with Image.open(path) as image:
+                text = pytesseract.image_to_string(image, lang="rus+eng")
+        except TesseractNotFoundError:
+            return None, False, False, "Исполняемый файл Tesseract OCR не найден."  # pragma: no cover
+        except Exception as error:  # pragma: no cover - зависит от конкретного файла
+            return None, False, False, f"Не удалось выполнить OCR: {error}"
+        cleaned = text.strip()
+        truncated_text, truncated_flag = _truncate(cleaned)
+        return truncated_text, truncated_flag, True, None
+
+    return None, False, False, "Формат вложения не поддерживается для автоматической расшифровки."
+
+
+def _decode_bytes(data: bytes) -> str:
+    """Подбирает корректную кодировку текста."""
+
+    for encoding in ("utf-8", "utf-16", "cp1251"):
+        try:
+            return data.decode(encoding)
+        except UnicodeDecodeError:
+            continue
+    return data.decode("utf-8", errors="ignore")
+
+
+def _truncate(text: str) -> Tuple[Optional[str], bool]:
+    """Ограничивает длину текста и добавляет флаг усечения."""
+
+    if not text:
+        return None, False
+    truncated = len(text) > MAX_TEXT_LENGTH
+    processed = text[:MAX_TEXT_LENGTH] if truncated else text
+    return processed, truncated
+
+
+__all__ = ["app"]

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import WelcomeScreen from "./components/WelcomeScreen";
 import ChatInput from "./components/ChatInput";
 import ChatView from "./components/ChatView";
 import type { ChatMessage } from "./types/chat";
+import type { AttachmentState, AttachmentUploadResponse } from "./types/attachments";
 import kolibriBridge from "./core/kolibri-bridge";
 
 const App = () => {
@@ -13,6 +14,12 @@ const App = () => {
   const [mode, setMode] = useState("Быстрый ответ");
   const [isProcessing, setIsProcessing] = useState(false);
   const [bridgeReady, setBridgeReady] = useState(false);
+  const [attachments, setAttachments] = useState<AttachmentState[]>([]);
+
+  const backendBaseUrl = useMemo(() => {
+    const raw = import.meta.env.VITE_BACKEND_URL ?? "";
+    return raw.replace(/\/+$/, "");
+  }, []);
 
   useEffect(() => {
     let cancelled = false;
@@ -52,6 +59,7 @@ const App = () => {
       setMessages([]);
       setDraft("");
       setIsProcessing(false);
+      setAttachments([]);
       return;
     }
 
@@ -60,6 +68,7 @@ const App = () => {
         await kolibriBridge.reset();
         setMessages([]);
         setDraft("");
+        setAttachments([]);
       } catch (error) {
         const assistantMessage: ChatMessage = {
           id: crypto.randomUUID(),
@@ -77,25 +86,124 @@ const App = () => {
     })();
   }, [bridgeReady]);
 
+  const handleAttachmentUpload = useCallback(
+    async (file: File) => {
+      const tempId = crypto.randomUUID();
+      const optimistic: AttachmentState = {
+        id: tempId,
+        filename: file.name,
+        status: "processing",
+      };
+      setAttachments((prev) => [...prev, optimistic]);
+
+      const endpoint = backendBaseUrl ? `${backendBaseUrl}/api/attachments` : "/api/attachments";
+      const formData = new FormData();
+      formData.append("file", file);
+
+      try {
+        const response = await fetch(endpoint, {
+          method: "POST",
+          body: formData,
+        });
+        if (!response.ok) {
+          const text = await response.text();
+          throw new Error(text || `Ошибка загрузки файла (${response.status})`);
+        }
+        const payload = (await response.json()) as AttachmentUploadResponse;
+        const normalisedDownloadUrl = (() => {
+          if (!payload.download_url) {
+            return undefined;
+          }
+          try {
+            const base = backendBaseUrl || globalThis.location?.origin || "";
+            return new URL(payload.download_url, base || undefined).toString();
+          } catch (error) {
+            console.error("Не удалось нормализовать ссылку вложения", error);
+            return payload.download_url;
+          }
+        })();
+
+        setAttachments((prev) =>
+          prev.map((item) =>
+            item.id === tempId
+              ? {
+                  ...item,
+                  status: "ready",
+                  contentType: payload.content_type,
+                  extractedText: payload.text,
+                  truncated: payload.truncated,
+                  downloadUrl: normalisedDownloadUrl,
+                  ocrPerformed: payload.ocr_performed,
+                  note: payload.note,
+                }
+              : item,
+          ),
+        );
+      } catch (error) {
+        const message = error instanceof Error ? error.message : "Не удалось загрузить файл.";
+        setAttachments((prev) =>
+          prev.map((item) =>
+            item.id === tempId
+              ? {
+                  ...item,
+                  status: "error",
+                  error: message,
+                }
+              : item,
+          ),
+        );
+      }
+    },
+    [backendBaseUrl],
+  );
+
+  const handleAttachmentRemove = useCallback((id: string) => {
+    setAttachments((prev) => prev.filter((item) => item.id !== id));
+  }, []);
+
   const sendMessage = useCallback(async () => {
-    const content = draft.trim();
-    if (!content || isProcessing || !bridgeReady) {
+    const readyAttachments = attachments.filter((item) => item.status === "ready");
+    const promptSegments: string[] = [];
+    const trimmedDraft = draft.trim();
+
+    if (trimmedDraft) {
+      promptSegments.push(trimmedDraft);
+    }
+
+    readyAttachments.forEach((attachment) => {
+      const lines: string[] = [`Вложение: ${attachment.filename}`];
+      if (attachment.extractedText) {
+        lines.push(attachment.extractedText);
+        if (attachment.truncated) {
+          lines.push("[Текст вложения был усечён для передачи]");
+        }
+      } else if (attachment.note) {
+        lines.push(attachment.note);
+      }
+      if (!attachment.extractedText && attachment.downloadUrl) {
+        lines.push(`Ссылка на вложение: ${attachment.downloadUrl}`);
+      }
+      promptSegments.push(lines.join("\n"));
+    });
+
+    if (!promptSegments.length || isProcessing || !bridgeReady) {
       return;
     }
 
     const userMessage: ChatMessage = {
       id: crypto.randomUUID(),
       role: "user",
-      content,
+      content: promptSegments.join("\n\n"),
       timestamp: new Date().toLocaleTimeString("ru-RU", { hour: "2-digit", minute: "2-digit" }),
     };
 
     setMessages((prev) => [...prev, userMessage]);
     setDraft("");
+    setAttachments([]);
     setIsProcessing(true);
 
     try {
-      const answer = await kolibriBridge.ask(content, mode);
+      const answer = await kolibriBridge.ask(userMessage.content, mode);
       const assistantMessage: ChatMessage = {
         id: crypto.randomUUID(),
         role: "assistant",
@@ -117,7 +225,7 @@ const App = () => {
     } finally {
       setIsProcessing(false);
     }
-  }, [bridgeReady, draft, isProcessing, mode]);
+  }, [attachments, bridgeReady, draft, isProcessing, mode]);
 
   const content = useMemo(() => {
     if (!messages.length) {
@@ -134,10 +242,14 @@ const App = () => {
         value={draft}
         mode={mode}
         isBusy={isProcessing || !bridgeReady}
+        attachments={attachments}
+        canSubmit={Boolean(draft.trim()) || attachments.some((item) => item.status === "ready")}
         onChange={setDraft}
         onModeChange={setMode}
         onSubmit={sendMessage}
         onReset={resetConversation}
+        onUploadFile={handleAttachmentUpload}
+        onRemoveAttachment={handleAttachmentRemove}
       />
     </Layout>
   );

--- a/frontend/src/components/ChatInput.tsx
+++ b/frontend/src/components/ChatInput.tsx
@@ -1,20 +1,51 @@
-import { Paperclip, Plus, RefreshCw, SendHorizontal } from "lucide-react";
-import { useId } from "react";
+import { Loader2, Paperclip, Plus, RefreshCw, SendHorizontal, X } from "lucide-react";
+import { ChangeEvent, useId, useRef } from "react";
+import type { AttachmentState } from "../types/attachments";
 
 interface ChatInputProps {
   value: string;
   mode: string;
   isBusy: boolean;
+  attachments: AttachmentState[];
+  canSubmit: boolean;
   onChange: (value: string) => void;
   onModeChange: (mode: string) => void;
   onSubmit: () => void;
   onReset: () => void;
+  onUploadFile: (file: File) => void;
+  onRemoveAttachment: (id: string) => void;
 }
 
 const modes = ["Быстрый ответ", "Исследование", "Творческий"];
 
-const ChatInput = ({ value, mode, isBusy, onChange, onModeChange, onSubmit, onReset }: ChatInputProps) => {
+const ChatInput = ({
+  value,
+  mode,
+  isBusy,
+  attachments,
+  canSubmit,
+  onChange,
+  onModeChange,
+  onSubmit,
+  onReset,
+  onUploadFile,
+  onRemoveAttachment,
+}: ChatInputProps) => {
   const textAreaId = useId();
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+
+  const handleFileButtonClick = () => {
+    fileInputRef.current?.click();
+  };
+
+  const handleFileChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const files = event.target.files;
+    if (!files?.length) {
+      return;
+    }
+    Array.from(files).forEach((file) => onUploadFile(file));
+    event.target.value = "";
+  };
 
   return (
     <div className="mt-6 flex flex-col gap-4 rounded-3xl bg-white/80 p-6 shadow-card">
@@ -48,16 +79,69 @@ const ChatInput = ({ value, mode, isBusy, onChange, onModeChange, onSubmit, onRe
         placeholder="Сообщение для Колибри"
         className="min-h-[120px] w-full resize-none rounded-2xl border border-transparent bg-background-light/60 px-4 py-3 text-sm text-text-dark placeholder:text-text-light focus:border-primary focus:outline-none"
       />
+      {attachments.length > 0 && (
+        <div className="flex flex-col gap-2 rounded-2xl bg-background-light/40 p-3">
+          {attachments.map((attachment) => {
+            let statusLabel: JSX.Element;
+
+            if (attachment.status === "processing") {
+              statusLabel = (
+                <span className="flex items-center gap-1 text-text-light">
+                  <Loader2 className="h-3 w-3 animate-spin" /> Обработка…
+                </span>
+              );
+            } else if (attachment.status === "error") {
+              statusLabel = (
+                <span className="text-accent-coral">{attachment.error ?? "Не удалось обработать."}</span>
+              );
+            } else {
+              statusLabel = (
+                <span className="text-text-light">
+                  {attachment.ocrPerformed ? "OCR выполнен" : "Готово"}
+                  {attachment.truncated ? " · усечено" : null}
+                </span>
+              );
+            }
+
+            return (
+              <div
+                key={attachment.id}
+                className="flex flex-wrap items-center gap-2 rounded-xl bg-white/40 px-3 py-2 text-xs text-text-dark"
+              >
+                <span className="font-semibold">{attachment.filename}</span>
+                {statusLabel}
+                <button
+                  type="button"
+                  onClick={() => onRemoveAttachment(attachment.id)}
+                  className="ml-auto flex items-center gap-1 rounded-lg bg-background-light/60 px-2 py-1 text-[11px] font-medium text-text-light transition-colors hover:text-text-dark"
+                >
+                  <X className="h-3 w-3" />
+                  Удалить
+                </button>
+              </div>
+            );
+          })}
+        </div>
+      )}
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div className="flex gap-2 text-text-light">
           <button
             type="button"
-            className="flex items-center gap-2 rounded-xl bg-background-light/60 px-3 py-2 text-xs font-semibold text-text-light transition-colors hover:text-text-dark"
+            className="flex items-center gap-2 rounded-xl bg-background-light/60 px-3 py-2 text-xs font-semibold text-text-light transition-colors hover:text-text-dark disabled:cursor-not-allowed disabled:opacity-60"
+            onClick={handleFileButtonClick}
             disabled={isBusy}
           >
             <Paperclip className="h-4 w-4" />
             Вложить
           </button>
+          <input
+            ref={fileInputRef}
+            type="file"
+            className="hidden"
+            multiple
+            onChange={handleFileChange}
+            accept=".txt,.md,.markdown,.csv,.json,.pdf,image/*"
+          />
           <button
             type="button"
             onClick={onReset}
@@ -81,7 +165,7 @@ const ChatInput = ({ value, mode, isBusy, onChange, onModeChange, onSubmit, onRe
             type="button"
             onClick={onSubmit}
             className="flex items-center gap-2 rounded-xl bg-primary px-4 py-2 text-sm font-semibold text-white transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
-            disabled={isBusy || !value.trim()}
+            disabled={isBusy || !canSubmit}
           >
             <SendHorizontal className="h-4 w-4" />
             Отправить

--- a/frontend/src/env.d.ts
+++ b/frontend/src/env.d.ts
@@ -1,0 +1,15 @@
+/// <reference types="vite/client" />
+
+declare namespace NodeJS {
+  interface ProcessEnv {
+    readonly VITE_BACKEND_URL?: string;
+  }
+}
+
+interface ImportMetaEnv {
+  readonly VITE_BACKEND_URL?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/frontend/src/types/attachments.ts
+++ b/frontend/src/types/attachments.ts
@@ -1,0 +1,25 @@
+export type AttachmentStatus = "processing" | "ready" | "error";
+
+export interface AttachmentUploadResponse {
+  attachment_id: string;
+  filename: string;
+  content_type: string;
+  text: string | null;
+  truncated: boolean;
+  download_url: string;
+  ocr_performed: boolean;
+  note: string | null;
+}
+
+export interface AttachmentState {
+  id: string;
+  filename: string;
+  status: AttachmentStatus;
+  contentType?: string;
+  extractedText?: string | null;
+  truncated?: boolean;
+  downloadUrl?: string;
+  ocrPerformed?: boolean;
+  note?: string | null;
+  error?: string;
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,7 @@ coverage[toml]>=7.4,<8
 pyright>=1.1.350,<1.2
 pytest>=7.4,<9
 ruff>=0.4.0,<0.5
+fastapi>=0.110.0,<0.111.0
+uvicorn>=0.29.0,<0.30.0
+python-multipart>=0.0.9,<0.0.10
+pypdf>=4.2.0,<5.0.0


### PR DESCRIPTION
## Summary
- add a FastAPI endpoint that stores uploads, extracts text via OCR/PDF readers when available, and serves download links
- extend the chat UI and state management to upload attachments, surface processing status, and append extracted text to prompts
- introduce shared attachment types, environment declarations, and backend dependencies required for the new workflow

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dbd0f13b88832397af9b776f62a85a