### PR TITLE
Add plugin registry for KolibriSim commands

### DIFF
--- a/core/tools.py
+++ b/core/tools.py
@@ -1,0 +1,46 @@
+"""Инфраструктура плагинов для чат-команд KolibriSim."""
+
+from __future__ import annotations
+
+from typing import Callable, Dict, Protocol, TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - используется только для подсказок типов
+    from .kolibri_sim import KolibriSim
+
+
+CommandHandler = Callable[["KolibriSim", str], str]
+
+
+class ToolPlugin(Protocol):
+    """Протокол плагина, регистрирующего команды KolibriSim."""
+
+    def register_commands(self, registry: "ToolRegistry") -> None:
+        """Регистрирует обработчики команд с помощью переданного реестра."""
+
+
+class ToolRegistry:
+    """Реестр чат-команд, предоставляемых плагинами."""
+
+    def __init__(self) -> None:
+        self._commands: Dict[str, CommandHandler] = {}
+
+    @staticmethod
+    def _normalize(command: str) -> str:
+        return command.strip().lower()
+
+    def register_command(self, command: str, handler: CommandHandler) -> None:
+        normalized = self._normalize(command)
+        if normalized in self._commands:
+            raise ValueError(f"команда уже зарегистрирована: {normalized}")
+        self._commands[normalized] = handler
+
+    def register_plugin(self, plugin: ToolPlugin) -> None:
+        plugin.register_commands(self)
+
+    def dispatch(self, sim: "KolibriSim", command: str, argument: str) -> str:
+        normalized = self._normalize(command)
+        handler = self._commands.get(normalized)
+        if handler is None:
+            raise ValueError(f"неизвестная команда: {normalized}")
+        return handler(sim, argument)
+

--- a/tests/test_kolibri_sim.py
+++ b/tests/test_kolibri_sim.py
@@ -103,6 +103,22 @@ def test_t9_chat_commands() -> None:
     assert sim.dobrovolnaya_otpravka("выражение", "2+2*2") == "6"
 
 
+def test_tool_plugin_extension() -> None:
+    sim = KolibriSim(zerno=13)
+
+    class EchoPlugin:
+        def register_commands(self, registry) -> None:
+            def handler(instance: KolibriSim, argument: str) -> str:
+                instance._registrirovat("ECHO", argument)
+                return argument.upper()
+
+            registry.register_command("эхо", handler)
+
+    sim.register_plugin(EchoPlugin())
+    assert sim.dobrovolnaya_otpravka("эхо", "проба") == "ПРОБА"
+    assert sim.zhurnal[-1]["tip"] == "ECHO"
+
+
 def test_t10_repl_guard(monkeypatch: pytest.MonkeyPatch) -> None:
     env = {"KOLIBRI_REPL": "1"}
     assert dolzhen_zapustit_repl(env, True) is True


### PR DESCRIPTION
## Summary
- introduce a tool registry and plugin protocol for KolibriSim chat commands
- refactor KolibriSim to register built-in knowledge, numeric, and sandbox command plugins
- add a regression test covering external plugin registration via the new registry

## Testing
- pytest tests/test_kolibri_sim.py

------
https://chatgpt.com/codex/tasks/task_e_68dbd137f5bc8323af2b573bf8d5515e