### PR TITLE
Add genome explorer and rule editor panels

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,9 +1,11 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import Layout from "./components/Layout";
-import Sidebar from "./components/Sidebar";
+import Sidebar, { type SidebarTab } from "./components/Sidebar";
 import WelcomeScreen from "./components/WelcomeScreen";
 import ChatInput from "./components/ChatInput";
 import ChatView from "./components/ChatView";
+import GenomeExplorer from "./components/GenomeExplorer";
+import RuleEditor from "./components/RuleEditor";
 import type { ChatMessage } from "./types/chat";
 import kolibriBridge from "./core/kolibri-bridge";
 
@@ -13,6 +15,7 @@ const App = () => {
   const [mode, setMode] = useState("Быстрый ответ");
   const [isProcessing, setIsProcessing] = useState(false);
   const [bridgeReady, setBridgeReady] = useState(false);
+  const [activeTab, setActiveTab] = useState<SidebarTab>("chat");
 
   useEffect(() => {
     let cancelled = false;
@@ -120,25 +123,38 @@ const App = () => {
   }, [bridgeReady, draft, isProcessing, mode]);
 
   const content = useMemo(() => {
-    if (!messages.length) {
-      return <WelcomeScreen onSuggestionSelect={handleSuggestionSelect} />;
+    if (activeTab === "chat") {
+      if (!messages.length) {
+        return <WelcomeScreen onSuggestionSelect={handleSuggestionSelect} />;
+      }
+      return <ChatView messages={messages} isLoading={isProcessing} />;
     }
 
-    return <ChatView messages={messages} isLoading={isProcessing} />;
-  }, [handleSuggestionSelect, isProcessing, messages]);
+    if (activeTab === "genome") {
+      return <GenomeExplorer />;
+    }
+
+    if (activeTab === "rules") {
+      return <RuleEditor />;
+    }
+
+    return null;
+  }, [activeTab, handleSuggestionSelect, isProcessing, messages]);
 
   return (
-    <Layout sidebar={<Sidebar />}>
+    <Layout sidebar={<Sidebar activeTab={activeTab} onSelect={setActiveTab} />}>
       <div className="flex-1">{content}</div>
-      <ChatInput
-        value={draft}
-        mode={mode}
-        isBusy={isProcessing || !bridgeReady}
-        onChange={setDraft}
-        onModeChange={setMode}
-        onSubmit={sendMessage}
-        onReset={resetConversation}
-      />
+      {activeTab === "chat" ? (
+        <ChatInput
+          value={draft}
+          mode={mode}
+          isBusy={isProcessing || !bridgeReady}
+          onChange={setDraft}
+          onModeChange={setMode}
+          onSubmit={sendMessage}
+          onReset={resetConversation}
+        />
+      ) : null}
     </Layout>
   );
 };

--- a/frontend/src/components/GenomeExplorer.tsx
+++ b/frontend/src/components/GenomeExplorer.tsx
@@ -1,0 +1,139 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { DatabaseZap, Loader2, RefreshCw } from "lucide-react";
+import kolibriBridge, { type GenomeBlock } from "../core/kolibri-bridge";
+
+const formatDigits = (value: string, group = 12) => {
+  if (!value) {
+    return "";
+  }
+  const chunks: string[] = [];
+  for (let index = 0; index < value.length; index += group) {
+    chunks.push(value.slice(index, index + group));
+  }
+  return chunks.join("\n");
+};
+
+const GenomeExplorer = () => {
+  const [blocks, setBlocks] = useState<GenomeBlock[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadBlocks = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const data = await kolibriBridge.fetchGenome();
+      setBlocks(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Не удалось загрузить геном");
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadBlocks();
+  }, [loadBlocks]);
+
+  const stats = useMemo(() => {
+    if (!blocks.length) {
+      return null;
+    }
+    const payloadDigits = blocks.reduce((sum, block) => sum + block.payload.length, 0);
+    return {
+      blocks: blocks.length,
+      payloadDigits,
+    };
+  }, [blocks]);
+
+  return (
+    <section className="space-y-6">
+      <header className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h2 className="text-2xl font-semibold text-text-dark">Цифровой геном</h2>
+          <p className="text-sm text-text-light">
+            Цепочка ReasonBlock с HMAC-подписями фиксирует каждое эволюционное событие.
+          </p>
+        </div>
+        <div className="flex items-center gap-3">
+          {stats ? (
+            <div className="flex items-center gap-2 rounded-2xl bg-white/80 px-3 py-2 text-xs font-medium text-text-dark shadow-sm">
+              <DatabaseZap className="h-4 w-4 text-primary" />
+              <span>
+                {stats.blocks} блоков • {stats.payloadDigits} цифр payload
+              </span>
+            </div>
+          ) : null}
+          <button
+            type="button"
+            onClick={loadBlocks}
+            disabled={isLoading}
+            className="flex items-center gap-2 rounded-xl bg-primary px-4 py-2 text-sm font-semibold text-white shadow-card transition hover:bg-primary/90 disabled:cursor-not-allowed disabled:bg-primary/60"
+          >
+            {isLoading ? <Loader2 className="h-4 w-4 animate-spin" /> : <RefreshCw className="h-4 w-4" />}
+            <span>{isLoading ? "Обновление" : "Обновить"}</span>
+          </button>
+        </div>
+      </header>
+
+      {error ? (
+        <div className="rounded-2xl border border-red-200 bg-red-50/80 p-4 text-sm text-red-700">
+          {error}
+        </div>
+      ) : null}
+
+      {isLoading && !blocks.length ? (
+        <div className="flex items-center gap-3 rounded-2xl border border-dashed border-primary/40 bg-white/70 p-6 text-sm text-text-light">
+          <Loader2 className="h-5 w-5 animate-spin text-primary" />
+          <span>Загружаем цепочку блоков…</span>
+        </div>
+      ) : null}
+
+      {!isLoading && !blocks.length && !error ? (
+        <div className="rounded-2xl border border-dashed border-text-light/30 bg-white/60 p-6 text-sm text-text-light">
+          Геном пока пуст. Проведите обучение или эволюцию формул, чтобы зафиксировать новое событие.
+        </div>
+      ) : null}
+
+      {blocks.length ? (
+        <div className="space-y-4">
+          {blocks.map((block) => (
+            <article key={block.nomer} className="rounded-3xl bg-white/90 p-6 shadow-card">
+              <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                <div>
+                  <h3 className="text-lg font-semibold text-text-dark">Блок №{block.nomer}</h3>
+                  <p className="text-xs uppercase tracking-wide text-text-light">Payload</p>
+                  <pre className="mt-1 max-h-32 overflow-auto rounded-2xl bg-background-light/60 p-3 text-xs font-mono leading-relaxed text-text-dark">
+                    {formatDigits(block.payload)}
+                  </pre>
+                </div>
+                <div className="flex flex-col gap-3 text-xs">
+                  <div>
+                    <p className="font-medium uppercase tracking-wide text-text-light">Предыдущий хеш</p>
+                    <p className="mt-1 rounded-xl bg-background-light/70 p-2 font-mono text-[11px] text-text-dark">
+                      {block.pred_hash}
+                    </p>
+                  </div>
+                  <div>
+                    <p className="font-medium uppercase tracking-wide text-text-light">HMAC (десятичный)</p>
+                    <p className="mt-1 rounded-xl bg-background-light/70 p-2 font-mono text-[11px] text-text-dark">
+                      {block.hmac_summa}
+                    </p>
+                  </div>
+                  <div>
+                    <p className="font-medium uppercase tracking-wide text-text-light">Итоговый хеш</p>
+                    <p className="mt-1 rounded-xl bg-background-light/70 p-2 font-mono text-[11px] text-text-dark">
+                      {block.itogovy_hash}
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </article>
+          ))}
+        </div>
+      ) : null}
+    </section>
+  );
+};
+
+export default GenomeExplorer;

--- a/frontend/src/components/NavItem.tsx
+++ b/frontend/src/components/NavItem.tsx
@@ -5,11 +5,13 @@ interface NavItemProps {
   icon: ElementType;
   label: string;
   active?: boolean;
+  onClick?: () => void;
 }
 
-const NavItem = ({ icon: Icon, label, active = false }: NavItemProps) => (
+const NavItem = ({ icon: Icon, label, active = false, onClick }: NavItemProps) => (
   <button
     type="button"
+    onClick={onClick}
     className={twMerge(
       "flex w-full items-center gap-3 rounded-xl px-4 py-3 text-left text-sm font-medium transition-colors",
       active

--- a/frontend/src/components/RuleEditor.tsx
+++ b/frontend/src/components/RuleEditor.tsx
@@ -1,0 +1,319 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { BrainCircuit, Loader2, PenSquare, Play, Plus, RefreshCw, Save } from "lucide-react";
+import kolibriBridge, {
+  type FormulaEvaluationRequest,
+  type FormulaEvaluationResult,
+  type FormulaSummary,
+  type SaveFormulaRequest,
+} from "../core/kolibri-bridge";
+
+const DEFAULT_CONTEXT_HINT = "Введите контекст, например math или demo";
+
+const RuleEditor = () => {
+  const [formulas, setFormulas] = useState<FormulaSummary[]>([]);
+  const [selectedName, setSelectedName] = useState<string | null>(null);
+  const [code, setCode] = useState("");
+  const [context, setContext] = useState("");
+  const [payload, setPayload] = useState("");
+  const [evaluation, setEvaluation] = useState<FormulaEvaluationResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const [isEvaluating, setIsEvaluating] = useState(false);
+
+  const selectedFormula = useMemo(
+    () => (selectedName ? formulas.find((item) => item.name === selectedName) ?? null : null),
+    [formulas, selectedName],
+  );
+
+  const loadFormulas = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const list = await kolibriBridge.fetchFormulas();
+      setFormulas(list);
+      if (!selectedName && list.length) {
+        setSelectedName(list[0].name);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Не удалось загрузить формулы");
+    } finally {
+      setIsLoading(false);
+    }
+  }, [selectedName]);
+
+  useEffect(() => {
+    void loadFormulas();
+  }, [loadFormulas]);
+
+  useEffect(() => {
+    if (selectedFormula) {
+      setCode(selectedFormula.code);
+      setContext(selectedFormula.context ?? "");
+      setEvaluation(null);
+      setError(null);
+    } else if (!selectedName) {
+      setCode("");
+      setContext("");
+      setPayload("");
+      setEvaluation(null);
+      setError(null);
+    }
+  }, [selectedFormula, selectedName]);
+
+  const handleSelect = (name: string) => {
+    setSelectedName(name);
+  };
+
+  const handleCreate = () => {
+    setSelectedName(null);
+    setCode("");
+    setContext("");
+    setPayload("");
+    setEvaluation(null);
+    setError(null);
+  };
+
+  const handleRefresh = () => {
+    void loadFormulas();
+  };
+
+  const persistFormula = async (request: SaveFormulaRequest) => {
+    setIsSaving(true);
+    setError(null);
+    try {
+      const updated = await kolibriBridge.saveFormula(request);
+      setFormulas((prev) => {
+        const withoutCurrent = prev.filter((item) => item.name !== updated.name);
+        return [...withoutCurrent, updated].sort((a, b) => a.name.localeCompare(b.name, "ru") || a.name.localeCompare(b.name));
+      });
+      setSelectedName(updated.name);
+      setEvaluation(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Не удалось сохранить формулу");
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleSave = async () => {
+    if (!code.trim()) {
+      setError("Введите код формулы перед сохранением.");
+      return;
+    }
+    const request: SaveFormulaRequest = {
+      name: selectedName ?? undefined,
+      code,
+      context: context.trim() || undefined,
+    };
+    await persistFormula(request);
+  };
+
+  const handleEvaluate = async () => {
+    if (!code.trim()) {
+      setError("Введите код формулы для оценки.");
+      return;
+    }
+    setIsEvaluating(true);
+    setError(null);
+    try {
+      const request: FormulaEvaluationRequest = {
+        name: selectedName ?? undefined,
+        code,
+        context: context.trim() || undefined,
+        payload: payload.trim() || undefined,
+      };
+      const result = await kolibriBridge.evaluateFormula(request);
+      setEvaluation(result);
+    } catch (err) {
+      setEvaluation({
+        success: false,
+        output: "",
+        message: err instanceof Error ? err.message : "Не удалось выполнить оценку",
+      });
+    } finally {
+      setIsEvaluating(false);
+    }
+  };
+
+  const evaluationBanner = useMemo(() => {
+    if (!evaluation) {
+      return null;
+    }
+    const style = evaluation.success ? "border-emerald-200 bg-emerald-50/90 text-emerald-800" : "border-red-200 bg-red-50/90 text-red-700";
+    return (
+      <div className={`rounded-2xl border p-4 text-sm ${style}`}>
+        <div className="flex flex-wrap items-center gap-3">
+          <span className="font-semibold">
+            {evaluation.success ? "Формула выполнена успешно" : "Ошибка при выполнении"}
+          </span>
+          {evaluation.fitness !== undefined ? (
+            <span className="rounded-xl bg-white/70 px-2 py-1 text-xs font-medium text-text-dark">
+              fitness: {evaluation.fitness.toFixed(3)}
+            </span>
+          ) : null}
+        </div>
+        {evaluation.output ? (
+          <pre className="mt-3 whitespace-pre-wrap text-xs font-mono leading-relaxed text-text-dark">
+            {evaluation.output}
+          </pre>
+        ) : null}
+        {evaluation.metadata ? (
+          <div className="mt-3 grid gap-2 text-xs text-text-dark">
+            {Object.entries(evaluation.metadata).map(([key, value]) => (
+              <div key={key} className="flex items-center justify-between gap-3 rounded-xl bg-white/70 px-3 py-1">
+                <span className="font-medium text-text-light">{key}</span>
+                <span className="font-mono">{value}</span>
+              </div>
+            ))}
+          </div>
+        ) : null}
+        {evaluation.message && !evaluation.success ? (
+          <p className="mt-3 text-xs font-medium text-text-dark">{evaluation.message}</p>
+        ) : null}
+      </div>
+    );
+  }, [evaluation]);
+
+  return (
+    <section className="grid gap-6 lg:grid-cols-[18rem_1fr] lg:gap-8">
+      <aside className="space-y-4">
+        <div className="flex items-center justify-between">
+          <h2 className="text-xl font-semibold text-text-dark">Формулы</h2>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={handleRefresh}
+              disabled={isLoading}
+              className="rounded-xl bg-background-light/70 p-2 text-text-light transition hover:text-text-dark disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {isLoading ? <Loader2 className="h-4 w-4 animate-spin" /> : <RefreshCw className="h-4 w-4" />}
+            </button>
+            <button
+              type="button"
+              onClick={handleCreate}
+              className="rounded-xl bg-primary/10 p-2 text-primary transition hover:bg-primary/20"
+            >
+              <Plus className="h-4 w-4" />
+            </button>
+          </div>
+        </div>
+        <div className="rounded-3xl bg-white/80 p-4 shadow-card">
+          {isLoading && !formulas.length ? (
+            <div className="flex items-center gap-3 text-sm text-text-light">
+              <Loader2 className="h-4 w-4 animate-spin text-primary" />
+              <span>Загружаем пул формул…</span>
+            </div>
+          ) : null}
+          {!isLoading && !formulas.length ? (
+            <p className="text-sm text-text-light">
+              Пул формул пуст. Создайте правило вручную или дождитесь эволюции ядра.
+            </p>
+          ) : null}
+          <ul className="mt-3 space-y-2">
+            {formulas.map((formula) => {
+              const isActive = selectedName === formula.name;
+              return (
+                <li key={formula.name}>
+                  <button
+                    type="button"
+                    onClick={() => handleSelect(formula.name)}
+                    className={`w-full rounded-2xl border px-3 py-2 text-left text-sm transition ${
+                      isActive
+                        ? "border-primary/50 bg-primary/10 text-text-dark"
+                        : "border-transparent bg-background-light/50 text-text-light hover:border-primary/40 hover:text-text-dark"
+                    }`}
+                  >
+                    <div className="flex items-center justify-between gap-3">
+                      <span className="font-semibold">{formula.name}</span>
+                      <span className="rounded-lg bg-white/80 px-2 py-0.5 text-xs font-mono text-primary">
+                        {formula.fitness.toFixed(3)}
+                      </span>
+                    </div>
+                    <p className="mt-1 truncate text-xs text-text-light">{formula.code}</p>
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      </aside>
+
+      <div className="space-y-5">
+        <header className="flex flex-wrap items-center gap-3">
+          <div className="flex items-center gap-2 rounded-2xl bg-white/80 px-3 py-2 text-sm font-medium text-text-dark shadow-card">
+            <BrainCircuit className="h-4 w-4 text-primary" />
+            <span>{selectedFormula ? `Редактирование ${selectedFormula.name}` : "Новая формула"}</span>
+          </div>
+          {selectedFormula?.parents.length ? (
+            <div className="flex items-center gap-2 rounded-2xl bg-background-light/60 px-3 py-2 text-xs text-text-light">
+              <PenSquare className="h-4 w-4" />
+              <span>Родители: {selectedFormula.parents.join(", ")}</span>
+            </div>
+          ) : null}
+        </header>
+
+        {error ? (
+          <div className="rounded-2xl border border-red-200 bg-red-50/80 p-3 text-sm text-red-700">{error}</div>
+        ) : null}
+
+        <div className="space-y-4 rounded-3xl bg-white/90 p-6 shadow-card">
+          <label className="block space-y-2 text-sm">
+            <span className="font-medium text-text-light">Код формулы</span>
+            <textarea
+              value={code}
+              onChange={(event) => setCode(event.target.value)}
+              rows={6}
+              className="w-full rounded-2xl border border-transparent bg-background-light/60 px-4 py-3 font-mono text-sm text-text-dark focus:border-primary focus:outline-none"
+              placeholder="f(x)=3*x+1"
+            />
+          </label>
+          <label className="block space-y-2 text-sm">
+            <span className="font-medium text-text-light">Контекст</span>
+            <input
+              type="text"
+              value={context}
+              onChange={(event) => setContext(event.target.value)}
+              className="w-full rounded-2xl border border-transparent bg-background-light/60 px-4 py-3 text-sm text-text-dark focus:border-primary focus:outline-none"
+              placeholder={DEFAULT_CONTEXT_HINT}
+            />
+          </label>
+          <label className="block space-y-2 text-sm">
+            <span className="font-medium text-text-light">Тестовая нагрузка</span>
+            <textarea
+              value={payload}
+              onChange={(event) => setPayload(event.target.value)}
+              rows={3}
+              className="w-full rounded-2xl border border-transparent bg-background-light/60 px-4 py-3 text-sm text-text-dark focus:border-primary focus:outline-none"
+              placeholder="Например: 0,1,2,3"
+            />
+          </label>
+          <div className="flex flex-wrap gap-3">
+            <button
+              type="button"
+              onClick={handleSave}
+              disabled={isSaving}
+              className="flex items-center gap-2 rounded-xl bg-primary px-4 py-2 text-sm font-semibold text-white shadow-card transition hover:bg-primary/90 disabled:cursor-not-allowed disabled:bg-primary/60"
+            >
+              {isSaving ? <Loader2 className="h-4 w-4 animate-spin" /> : <Save className="h-4 w-4" />}
+              <span>{selectedFormula ? "Сохранить изменения" : "Создать формулу"}</span>
+            </button>
+            <button
+              type="button"
+              onClick={handleEvaluate}
+              disabled={isEvaluating}
+              className="flex items-center gap-2 rounded-xl border border-primary/50 bg-white px-4 py-2 text-sm font-semibold text-primary shadow-sm transition hover:bg-primary/10 disabled:cursor-not-allowed disabled:border-primary/20 disabled:text-primary/50"
+            >
+              {isEvaluating ? <Loader2 className="h-4 w-4 animate-spin" /> : <Play className="h-4 w-4" />}
+              <span>Оценить</span>
+            </button>
+          </div>
+        </div>
+
+        {evaluationBanner}
+      </div>
+    </section>
+  );
+};
+
+export default RuleEditor;

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,14 +1,21 @@
-import {
-  BarChart3,
-  Bot,
-  Clock3,
-  MessageCircle,
-  Settings,
-  Sparkles,
-} from "lucide-react";
+import type { ElementType } from "react";
+import { Bot, Dna, MessageCircle, PenTool, Sparkles } from "lucide-react";
 import NavItem from "./NavItem";
 
-const Sidebar = () => (
+export type SidebarTab = "chat" | "genome" | "rules";
+
+interface SidebarProps {
+  activeTab: SidebarTab;
+  onSelect(tab: SidebarTab): void;
+}
+
+const NAVIGATION: Array<{ key: SidebarTab; icon: ElementType; label: string }> = [
+  { key: "chat", icon: MessageCircle, label: "Диалоги" },
+  { key: "genome", icon: Dna, label: "Геном" },
+  { key: "rules", icon: PenTool, label: "Правила" },
+];
+
+const Sidebar = ({ activeTab, onSelect }: SidebarProps) => (
   <div className="flex h-full flex-col justify-between rounded-3xl bg-background-sidebar/70 p-6 backdrop-blur-xl">
     <div className="space-y-8">
       <div className="flex items-center gap-3">
@@ -21,11 +28,16 @@ const Sidebar = () => (
         </div>
       </div>
       <nav className="space-y-2">
-        <NavItem icon={MessageCircle} label="Диалоги" active />
+        {NAVIGATION.map((item) => (
+          <NavItem
+            key={item.key}
+            icon={item.icon}
+            label={item.label}
+            active={activeTab === item.key}
+            onClick={() => onSelect(item.key)}
+          />
+        ))}
         <NavItem icon={Sparkles} label="Действия" />
-        <NavItem icon={BarChart3} label="Визуализация" />
-        <NavItem icon={Clock3} label="История" />
-        <NavItem icon={Settings} label="Настройки" />
       </nav>
     </div>
     <div className="flex items-center gap-3 rounded-2xl bg-white/70 p-3">


### PR DESCRIPTION
## Summary
- add sidebar navigation state so chat, genome, and rule editing panels can be opened from the shell
- implement a genome explorer that surfaces blocks from the Kolibri chain with HMAC metadata
- deliver a rule editor UI wired to bridge APIs for loading, saving, and evaluating formulas

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dbd56176ec8323aeb6113e0c08fff3