### PR TITLE
Refine soak runner and add regression tests

### DIFF
--- a/core/kolibri_sim.py
+++ b/core/kolibri_sim.py
@@ -12,15 +12,7 @@ import hmac
 import os
 from pathlib import Path
 
-from typing import Any, Dict, List, Mapping, Optional, Sequence, TypedDict, cast
-
-
-class FormulaRecord(TypedDict):
-    """Структура формулы, эволюционирующей в KolibriSim."""
-
-
-
-from typing import Dict, List, Mapping, Optional, Protocol, TypedDict, cast
+from typing import Any, Dict, List, Mapping, Optional, Protocol, Sequence, TypedDict, cast
 
 from .tracing import JsonLinesTracer
 
@@ -45,6 +37,7 @@ class ZhurnalTracer(Protocol):
 
 
 class FormulaZapis(TypedDict):
+    """Структура формулы, эволюционирующей в KolibriSim."""
 
     kod: str
     fitness: float
@@ -52,10 +45,9 @@ class FormulaZapis(TypedDict):
     context: str
 
 
-
-class MetricRecord(TypedDict):
+class MetricEntry(TypedDict):
     """Метрика одного шага soak-прогона."""
-    
+
     minute: int
     formula: str
     fitness: float
@@ -65,9 +57,6 @@ class MetricRecord(TypedDict):
 class SoakResult(TypedDict):
 
     """Результат выполнения soak-сессии."""
-
-    events: int
-    metrics: List[MetricRecord]
 
     events: int
     metrics: List[MetricEntry]
@@ -141,8 +130,6 @@ class KolibriSim:
         self._zhurnal_sdvig = 0
 
         self.znanija: Dict[str, str] = {}
-
-        self.formuly: Dict[str, FormulaRecord] = {}
 
         self.formuly: Dict[str, FormulaZapis] = {}
 
@@ -326,8 +313,6 @@ class KolibriSim:
         kod = f"f(x)={mnozhitel}*x+{smeshchenie}"
         nazvanie = f"F{len(self.formuly) + 1:04d}"
 
-        zapis: FormulaRecord = {
-
         zapis: FormulaZapis = {
 
             "kod": kod,
@@ -446,8 +431,6 @@ class KolibriSim:
         """Имитация длительного прогона: создаёт формулы и записи генома."""
         nachalnyj_razmer = len(self.genom)
 
-        metrika: List[MetricRecord] = []
-
         metrika: List[MetricEntry] = []
 
         for minuta in range(minuti):
@@ -489,9 +472,6 @@ def zagruzit_sostoyanie(path: Path) -> Dict[str, Any]:
         rezultat[k] = json.loads(tekst)
     return rezultat
 
-
-
-def obnovit_soak_state(path: Path, sim: KolibriSim, minuti: int) -> Dict[str, Any]:
 
 def obnovit_soak_state(path: Path, sim: KolibriSim, minuti: int) -> SoakState:
 

--- a/tests/test_soak_script.py
+++ b/tests/test_soak_script.py
@@ -1,0 +1,117 @@
+"""Регрессионные тесты для сценария длительного прогона Kolibri."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import List
+from unittest.mock import patch
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from core.kolibri_sim import MetricEntry, zagruzit_sostoyanie
+from scripts import soak
+
+
+def _run_soak(capsys: pytest.CaptureFixture[str], args: List[str]) -> dict:
+    argv = ["soak"] + args
+    with patch.object(sys, "argv", argv):
+        exit_code = soak.main()
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    return json.loads(captured.out)
+
+
+def test_soak_resume_accumulates_state(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    state_path = tmp_path / "state.json"
+    log_dir = tmp_path / "logs"
+
+    result_first = _run_soak(
+        capsys,
+        [
+            "--minutes",
+            "1",
+            "--state-path",
+            str(state_path),
+            "--log-dir",
+            str(log_dir),
+            "--seed",
+            "123",
+        ],
+    )
+
+    assert result_first["metrics_written"] == 1
+    state_after_first = zagruzit_sostoyanie(state_path)
+    metrics_first = state_after_first.get("metrics")
+    assert isinstance(metrics_first, list)
+    assert len(metrics_first) == 1
+
+    result_second = _run_soak(
+        capsys,
+        [
+            "--minutes",
+            "1",
+            "--state-path",
+            str(state_path),
+            "--log-dir",
+            str(log_dir),
+            "--seed",
+            "123",
+            "--resume",
+        ],
+    )
+
+    assert result_second["metrics_written"] == 1
+    state_after_second = zagruzit_sostoyanie(state_path)
+    metrics_second = state_after_second.get("metrics")
+    assert isinstance(metrics_second, list)
+    assert len(metrics_second) == 2
+    assert state_after_second.get("events", 0) >= state_after_first.get("events", 0)
+
+
+def test_zapisat_csv_outputs_expected_rows(tmp_path: Path) -> None:
+    csv_path = tmp_path / "metrics.csv"
+    metrics: List[MetricEntry] = [
+        {"minute": 0, "formula": "f0", "fitness": 1.23, "genome": 42},
+        {"minute": 1, "formula": "f1", "fitness": 2.34, "genome": 84},
+    ]
+
+    soak.zapisat_csv(csv_path, metrics)
+
+    lines = csv_path.read_text(encoding="utf-8").splitlines()
+    assert lines[0] == "minute,formula,fitness,genome"
+    assert len(lines) == 3
+    first_row = lines[1].split(",")
+    assert first_row == ["0", "f0", "1.23", "42"]
+
+
+def test_soak_tracing_creates_log(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    state_path = tmp_path / "state.json"
+    log_dir = tmp_path / "logs"
+
+    result = _run_soak(
+        capsys,
+        [
+            "--minutes",
+            "1",
+            "--state-path",
+            str(state_path),
+            "--log-dir",
+            str(log_dir),
+            "--seed",
+            "314",
+        ],
+    )
+
+    trace_path_str = result["trace_path"]
+    assert trace_path_str
+    trace_path = Path(trace_path_str)
+    assert trace_path.exists()
+    content = trace_path.read_text(encoding="utf-8").strip().splitlines()
+    assert content
+    json.loads(content[0])


### PR DESCRIPTION
## Summary
- define the MetricEntry typed dict in KolibriSim and remove duplicate soak helpers
- update the soak runner to reuse a single KolibriSim instance and keep a single CSV exporter signature
- add pytest regression tests covering resume mode, CSV export, and tracing

## Testing
- pytest tests/test_soak_script.py

------
https://chatgpt.com/codex/tasks/task_e_68dbd55375e48323888f4883cbe2a315