### PR TITLE
Add shared MetricEntry type for soak metrics

### DIFF
--- a/core/kolibri_sim.py
+++ b/core/kolibri_sim.py
@@ -5,22 +5,14 @@ from __future__ import annotations
 import ast
 import dataclasses
 import json
+import os
 import random
 import time
 import hashlib
 import hmac
-import os
 from pathlib import Path
 
-from typing import Any, Dict, List, Mapping, Optional, Sequence, TypedDict, cast
-
-
-class FormulaRecord(TypedDict):
-    """Структура формулы, эволюционирующей в KolibriSim."""
-
-
-
-from typing import Dict, List, Mapping, Optional, Protocol, TypedDict, cast
+from typing import Any, Dict, List, Mapping, Optional, Protocol, Sequence, TypedDict, cast
 
 from .tracing import JsonLinesTracer
 
@@ -45,17 +37,15 @@ class ZhurnalTracer(Protocol):
 
 
 class FormulaZapis(TypedDict):
-
     kod: str
     fitness: float
     parents: List[str]
     context: str
 
 
-
-class MetricRecord(TypedDict):
+class MetricEntry(TypedDict):
     """Метрика одного шага soak-прогона."""
-    
+
     minute: int
     formula: str
     fitness: float
@@ -63,11 +53,7 @@ class MetricRecord(TypedDict):
 
 
 class SoakResult(TypedDict):
-
     """Результат выполнения soak-сессии."""
-
-    events: int
-    metrics: List[MetricRecord]
 
     events: int
     metrics: List[MetricEntry]
@@ -141,8 +127,6 @@ class KolibriSim:
         self._zhurnal_sdvig = 0
 
         self.znanija: Dict[str, str] = {}
-
-        self.formuly: Dict[str, FormulaRecord] = {}
 
         self.formuly: Dict[str, FormulaZapis] = {}
 
@@ -326,8 +310,6 @@ class KolibriSim:
         kod = f"f(x)={mnozhitel}*x+{smeshchenie}"
         nazvanie = f"F{len(self.formuly) + 1:04d}"
 
-        zapis: FormulaRecord = {
-
         zapis: FormulaZapis = {
 
             "kod": kod,
@@ -446,8 +428,6 @@ class KolibriSim:
         """Имитация длительного прогона: создаёт формулы и записи генома."""
         nachalnyj_razmer = len(self.genom)
 
-        metrika: List[MetricRecord] = []
-
         metrika: List[MetricEntry] = []
 
         for minuta in range(minuti):
@@ -488,10 +468,6 @@ def zagruzit_sostoyanie(path: Path) -> Dict[str, Any]:
         tekst = vosstanovit_tekst_iz_cifr(v)
         rezultat[k] = json.loads(tekst)
     return rezultat
-
-
-
-def obnovit_soak_state(path: Path, sim: KolibriSim, minuti: int) -> Dict[str, Any]:
 
 def obnovit_soak_state(path: Path, sim: KolibriSim, minuti: int) -> SoakState:
 


### PR DESCRIPTION
## Summary
- introduce a shared `MetricEntry` TypedDict for Kolibri soak metrics and adopt it across the simulator state helpers
- update the soak runner to import the shared metric schema and clean up CSV/event serialization

## Testing
- pytest tests/test_kolibri_sim.py

------
https://chatgpt.com/codex/tasks/task_e_68dbd5513e5883239990e0c4c9484cc3