### PR TITLE
Revise Kolibri simulator and soak utilities

### DIFF
--- a/core/kolibri_script/genome.py
+++ b/core/kolibri_script/genome.py
@@ -202,8 +202,8 @@ class KolibriGenomeLedger:
     def append(self, block: Mapping[str, Any], journal_entry: Mapping[str, Any]) -> None:
         """Добавляет запись в журнал и сбрасывает файл atomically."""
 
-        block_dict = _ensure_plain_mapping(block)
-        entry_dict = _ensure_plain_mapping(journal_entry)
+        block_dict = dict(_ensure_plain_mapping(block))
+        entry_dict = dict(_ensure_plain_mapping(journal_entry))
         entry_dict["block"] = block_dict
         self._records.append(entry_dict)
         self._flush()
@@ -243,7 +243,7 @@ def _collect_from_value(value: Any) -> Iterable[str]:
 
 
 def _to_plain(value: Any) -> Any:
-    if dataclasses.is_dataclass(value):
+    if dataclasses.is_dataclass(value) and not isinstance(value, type):
         return _to_plain(dataclasses.asdict(value))
     if isinstance(value, Mapping):
         return {str(key): _to_plain(val) for key, val in value.items()}

--- a/scripts/ci_bootstrap.sh
+++ b/scripts/ci_bootstrap.sh
@@ -4,6 +4,6 @@ set -euo pipefail
 PYTHON_BIN="${PYTHON:-python3}"
 
 $PYTHON_BIN -m pip install --upgrade pip
-$PYTHON_BIN -m pip install pytest ruff pyright coverage
+$PYTHON_BIN -m pip install pytest ruff pyright coverage fastapi pydantic asyncpg clickhouse-connect
 
 echo "Инструменты установлены: pytest, ruff, pyright, coverage"

--- a/scripts/soak.py
+++ b/scripts/soak.py
@@ -7,31 +7,19 @@ import argparse
 import csv
 import json
 from pathlib import Path
-
 from typing import Sequence, cast
 
-from core.kolibri_sim import KolibriSim, MetricRecord, obnovit_soak_state
+from core.kolibri_sim import KolibriSim, MetricRecord, SoakState, obnovit_soak_state
 
 
 def zapisat_csv(path: Path, metrika: Sequence[MetricRecord]) -> None:
-
-from typing import List, Optional, cast
-
-from core.kolibri_sim import (
-    KolibriSim,
-    MetricEntry,
-    SoakState,
-    obnovit_soak_state,
-)
-
-
-def zapisat_csv(path: Path, metrika: List[MetricEntry]) -> None:
-
     """Сохраняет метрики прогона в CSV."""
-    if not metrika:
-        path.write_text("minute,formula,fitness,genome\n", encoding="utf-8")
-        return
+
     fieldnames = ["minute", "formula", "fitness", "genome"]
+    if not metrika:
+        path.write_text(",".join(fieldnames) + "\n", encoding="utf-8")
+        return
+
     with path.open("w", newline="", encoding="utf-8") as csvfile:
         writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
         writer.writeheader()
@@ -42,7 +30,12 @@ def zapisat_csv(path: Path, metrika: List[MetricEntry]) -> None:
 def main() -> int:
     parser = argparse.ArgumentParser(description="Kolibri soak runner")
     parser.add_argument("--hours", type=float, default=4.0, help="длительность чанка в часах")
-    parser.add_argument("--minutes", type=int, default=None, help="длительность чанка в минутах (приоритетнее, чем часы)")
+    parser.add_argument(
+        "--minutes",
+        type=int,
+        default=None,
+        help="длительность чанка в минутах (приоритетнее, чем часы)",
+    )
     parser.add_argument("--resume", action="store_true", help="сохранять и продолжать существующее состояние")
     parser.add_argument("--state-path", default="soak_state.json", help="путь к файлу состояния")
     parser.add_argument("--metrics-path", default=None, help="путь к CSV с метриками")
@@ -60,27 +53,21 @@ def main() -> int:
     if not args.resume and state_path.exists():
         state_path.unlink()
 
-
-    sim = KolibriSim(zerno=args.seed)
-    rezultat = obnovit_soak_state(state_path, sim, minuti)
-    metrika = cast(Sequence[MetricRecord], rezultat.get("metrics", []))[-minuti:]
-
     log_dir = Path(args.log_dir) if args.log_dir is not None else Path("logs")
     trace_path = log_dir / f"kolibri_seed{args.seed}_events.jsonl"
+
     sim = KolibriSim(
         zerno=args.seed,
         trace_path=trace_path,
         trace_include_genome=args.keep_genome,
     )
     rezultat: SoakState = obnovit_soak_state(state_path, sim, minuti)
-    metrics = rezultat.get("metrics", [])
-    metrika = cast(List[MetricEntry], metrics)[-minuti:]
-
+    metrics = cast(Sequence[MetricRecord], rezultat.get("metrics", []))[-minuti:]
 
     if args.metrics_path:
-        zapisat_csv(Path(args.metrics_path), metrika)
+        zapisat_csv(Path(args.metrics_path), metrics)
 
-    genome_path: Optional[Path] = None
+    genome_path: Path | None = None
     if args.keep_genome:
         log_dir.mkdir(parents=True, exist_ok=True)
         genome_path = log_dir / f"kolibri_seed{args.seed}_genome.json"
@@ -89,14 +76,15 @@ def main() -> int:
             encoding="utf-8",
         )
 
-    print(json.dumps({
+    summary = {
         "minutes": minuti,
         "events": cast(int, rezultat.get("events", 0)),
-        "metrics_written": len(metrika),
+        "metrics_written": len(metrics),
         "state_path": str(state_path),
         "trace_path": str(sim.poluchit_trace_path() or trace_path),
         "genome_path": str(genome_path) if genome_path else None,
-    }, ensure_ascii=False, indent=2))
+    }
+    print(json.dumps(summary, ensure_ascii=False, indent=2))
     return 0
 
 


### PR DESCRIPTION
## Summary
- Rebuild the Kolibri simulator module with explicit typed records, resilient journaling and soak-state helpers for the test suite.
- Refresh the soak CLI to emit CSV metrics, manage trace/genome artifacts and interoperate with the new simulator APIs.
- Harden feedback storage by lazily importing database drivers, and extend the bootstrap script to install FastAPI-related dependencies for static analysis.
- Normalize genome ledger handling of dataclass blocks so stored mappings remain serializable.

## Testing
- bash scripts/ci_bootstrap.sh
- pyright
- ruff check .
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68dbf174fe8483239ada4968f01dc04a