### PR TITLE
feat: automate conflict resolver rebase workflow

### DIFF
--- a/.github/workflows/conflict-resolver.yml
+++ b/.github/workflows/conflict-resolver.yml
@@ -34,8 +34,20 @@ jobs:
           git config rerere.enabled true
       - name: Run conflict resolver
         id: run_conflict_resolver
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
-          python scripts/resolve_conflicts.py --report conflict-report.json
+          set -euo pipefail
+          BASE="${BASE_REF:-origin/main}"
+          if [[ "$BASE" != origin/* ]]; then
+            BASE="origin/$BASE"
+          fi
+          HEAD="${HEAD_REF:-work}"
+          BASE_NAME="${BASE#origin/}"
+          git fetch origin "$BASE_NAME":"$BASE_NAME"
+          git fetch origin "$HEAD:$HEAD"
+          python scripts/resolve_conflicts.py --base "$BASE" --head "$HEAD" --report conflict-report.json
       - name: Run bootstrap checks
         id: bootstrap
         run: |

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -25,7 +25,7 @@
 - Для локальной подготовки окружения используйте `scripts/ci_bootstrap.sh`.
 
 ## Скрипты
-- `scripts/resolve_conflicts.py` — авторазрешение конфликтов с генерацией JSON-отчёта.
+- `scripts/resolve_conflicts.py` — авторазрешение конфликтов (`--base`, `--head`, отчёт по умолчанию пишется в `build/conflict-report.json`).
 - `scripts/soak.py` — длительные прогоны симуляции Kolibri с накоплением метрик.
 - `scripts/post_pr_comment.py` — добавление комментариев в PR и формирование сторожевых отчётов.
 - Все скрипты должны быть исполняемыми (`chmod +x`).

--- a/docs/conflict_resolution.md
+++ b/docs/conflict_resolution.md
@@ -7,8 +7,8 @@
 
 ### Быстрый путь с `scripts/resolve_conflicts.py`
 1. Обновите ссылки на удалённые ветки: `git fetch --all --prune`.
-2. Запустите автоматизированный скрипт: `python scripts/resolve_conflicts.py --base origin/main --head work`.
-3. Изучите сгенерированный JSON-отчёт в `build/conflict-report.json`, убедитесь, что все файлы промаркированы как `resolved`.
+2. Запустите автоматизированный скрипт: `python scripts/resolve_conflicts.py --base origin/main --head work`. Он проверит merge-base, выполнит `git rebase origin/main` для ветки `work` и попытается автоматически снять конфликтные маркеры.
+3. Изучите сгенерированный JSON-отчёт в `build/conflict-report.json` (можно переопределить через `--report`), убедитесь, что все файлы промаркированы как `resolved`.
 4. Выполните `make`, `make test`, `./kolibri.sh up` для проверки целостности и работоспособности.
 5. Просмотрите дифф и зафиксируйте изменения коммитом с пометкой `[autofix conflicts]`.
 
@@ -34,8 +34,8 @@ This guide captures the recommended sequence for resolving merge conflicts while
 
 ### Fast path with `scripts/resolve_conflicts.py`
 1. Refresh remotes: `git fetch --all --prune`.
-2. Run the helper: `python scripts/resolve_conflicts.py --base origin/main --head work`.
-3. Inspect the generated report `build/conflict-report.json` and verify that every entry is marked `resolved`.
+2. Run the helper: `python scripts/resolve_conflicts.py --base origin/main --head work`. The script computes the merge-base, rebases `work` onto `origin/main`, and clears conflict markers using Kolibri heuristics.
+3. Inspect the generated report `build/conflict-report.json` (override via `--report` if necessary) and verify that every entry is marked `resolved`.
 4. Execute `make`, `make test`, and `./kolibri.sh up` to validate the fix.
 5. Review the diff and create a commit tagged `[autofix conflicts]` once satisfied.
 
@@ -61,8 +61,8 @@ This guide captures the recommended sequence for resolving merge conflicts while
 
 ### 使用 `scripts/resolve_conflicts.py` 的快速流程
 1. 刷新远端：`git fetch --all --prune`。
-2. 运行辅助脚本：`python scripts/resolve_conflicts.py --base origin/main --head work`。
-3. 查看 `build/conflict-report.json`，确认所有条目标记为 `resolved`。
+2. 运行辅助脚本：`python scripts/resolve_conflicts.py --base origin/main --head work`。脚本会先计算 merge-base，再对 `work` 执行 `git rebase origin/main` 并尝试清理冲突标记。
+3. 查看 `build/conflict-report.json`（可通过 `--report` 指定其他路径），确认所有条目标记为 `resolved`。
 4. 依次执行 `make`、`make test`、`./kolibri.sh up` 验证修复结果。
 5. 检查差异并在满意后创建带有 `[autofix conflicts]` 标记的提交。
 

--- a/scripts/resolve_conflicts.py
+++ b/scripts/resolve_conflicts.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
+import subprocess
 import sys
 from pathlib import Path
 from typing import Dict, List
@@ -12,6 +14,43 @@ from typing import Dict, List
 KONFLIKT_START = "<<<<<<<"
 KONFLIKT_DELIM = "======="
 KONFLIKT_END = ">>>>>>>"
+
+
+class GitCommandError(RuntimeError):
+    """Исключение, описывающее неудачную команду git."""
+
+    def __init__(self, cmd: List[str], result: subprocess.CompletedProcess[str]):
+        soobshchenie = (
+            f"Команда git {' '.join(cmd)} завершилась с кодом {result.returncode}.\n"
+            f"stdout:\n{result.stdout}\n"
+            f"stderr:\n{result.stderr}"
+        )
+        super().__init__(soobshchenie)
+        self.cmd = cmd
+        self.returncode = result.returncode
+        self.stdout = result.stdout
+        self.stderr = result.stderr
+
+
+def run_git(args: List[str], repo_root: Path, *, check: bool = True) -> subprocess.CompletedProcess[str]:
+    """Запускает git-команду и возвращает результат, поднимая ошибку при неуспехе."""
+
+    okruzhenie = os.environ.copy()
+    okruzhenie.setdefault("GIT_EDITOR", "true")
+    okruzhenie.setdefault("GIT_MERGE_AUTOEDIT", "no")
+    okruzhenie.setdefault("GIT_TERMINAL_PROMPT", "0")
+    okruzhenie.setdefault("GIT_PAGER", "cat")
+    rezultat = subprocess.run(
+        ["git", *args],
+        cwd=repo_root,
+        text=True,
+        capture_output=True,
+        check=False,
+        env=okruzhenie,
+    )
+    if check and rezultat.returncode != 0:
+        raise GitCommandError(args, rezultat)
+    return rezultat
 
 
 def razobrat_konflikt(lines: List[str]) -> List[str]:
@@ -45,47 +84,106 @@ def razobrat_konflikt(lines: List[str]) -> List[str]:
     return rezultat
 
 
-def obrabotat_fajl(path: Path) -> Dict[str, object]:
+def obrabotat_fajl(path: Path, root: Path) -> Dict[str, object]:
     """Читает файл, устраняет конфликтные маркеры и возвращает отчёт."""
     soderzhimoe = path.read_text(encoding="utf-8")
+    otnositelnyj = str(path.relative_to(root))
     if KONFLIKT_START not in soderzhimoe:
-        return {"file": str(path), "status": "clean"}
+        return {"file": otnositelnyj, "status": "clean"}
     stroki = soderzhimoe.splitlines(keepends=True)
     novye = razobrat_konflikt(stroki)
     path.write_text("".join(novye), encoding="utf-8")
-    return {"file": str(path), "status": "resolved"}
+    return {"file": otnositelnyj, "status": "resolved"}
 
 
 def nayti_fajly(root: Path) -> List[Path]:
-    """Возвращает список отслеживаемых файлов с потенциальными конфликтами."""
-    return [
-        path
-        for path in root.rglob("*")
-        if path.is_file() and not path.name.startswith(".")
-    ]
+    """Возвращает список файлов в конфликте согласно git."""
+
+    rezultat = run_git(["diff", "--name-only", "--diff-filter=U"], root)
+    fajly = [stroka.strip() for stroka in rezultat.stdout.splitlines() if stroka.strip()]
+    return [root / fajl for fajl in fajly]
 
 
-def postroit_otchet(root: Path) -> Dict[str, object]:
+def postroit_otchet(root: Path, fajly: List[Path]) -> Dict[str, object]:
     """Формирует итоговый отчёт по всем обработанным файлам."""
     rezultaty: List[Dict[str, object]] = []
-    for fajl in nayti_fajly(root):
+    for fajl in fajly:
         try:
-            rezultaty.append(obrabotat_fajl(fajl))
+            rezultaty.append(obrabotat_fajl(fajl, root))
         except UnicodeDecodeError:
-            rezultaty.append({"file": str(fajl), "status": "skipped"})
+            rezultaty.append({"file": str(fajl.relative_to(root)), "status": "skipped"})
     return {"files": rezultaty}
 
 
 def main(argv: List[str]) -> int:
     parser = argparse.ArgumentParser(description="Автоконфликт Kolibri")
-    parser.add_argument("--report", type=Path, default=None, help="путь для JSON-отчёта")
+    parser.add_argument("--base", required=True, help="базовая ветка/коммит для ребейза")
+    parser.add_argument("--head", required=True, help="рабочая ветка с конфликтами")
+    parser.add_argument(
+        "--report",
+        type=Path,
+        default=Path("build/conflict-report.json"),
+        help="путь для JSON-отчёта",
+    )
     args = parser.parse_args(argv)
-    koren = Path.cwd()
-    otchet = postroit_otchet(koren)
-    if args.report:
-        args.report.write_text(json.dumps(otchet, ensure_ascii=False, indent=2), encoding="utf-8")
-    print(json.dumps(otchet, ensure_ascii=False, indent=2))
-    return 0
+    try:
+        koren = Path(
+            run_git(["rev-parse", "--show-toplevel"], Path.cwd()).stdout.strip()
+        )
+        report_path = args.report
+        if report_path and not report_path.is_absolute():
+            report_path = koren / report_path
+        merge_base = run_git(["merge-base", args.base, args.head], koren).stdout.strip()
+        run_git(["checkout", args.head], koren)
+
+        otchet_fajlov: List[Dict[str, object]] = []
+        rezultat_rebase = run_git(["rebase", args.base], koren, check=False)
+        if rezultat_rebase.returncode not in (0, 1):
+            raise GitCommandError(["rebase", args.base], rezultat_rebase)
+
+        if rezultat_rebase.returncode == 1:
+            while True:
+                fajly_v_konflikte = nayti_fajly(koren)
+                chastichnyj_otchet = postroit_otchet(koren, fajly_v_konflikte)
+                otchet_fajlov.extend(chastichnyj_otchet["files"])
+                razreshennye = [
+                    zapis["file"]
+                    for zapis in chastichnyj_otchet["files"]
+                    if zapis["status"] == "resolved"
+                ]
+                problemnye = [
+                    zapis["file"]
+                    for zapis in chastichnyj_otchet["files"]
+                    if zapis["status"] != "clean"
+                ]
+                if not razreshennye and problemnye:
+                    raise RuntimeError(
+                        "Обнаружены файлы, которые не удалось обработать автоматически: "
+                        + ", ".join(problemnye)
+                    )
+                if razreshennye:
+                    run_git(["add", *razreshennye], koren)
+                rezultat_continue = run_git(["rebase", "--continue"], koren, check=False)
+                if rezultat_continue.returncode == 0:
+                    break
+                if rezultat_continue.returncode == 1:
+                    continue
+                raise GitCommandError(["rebase", "--continue"], rezultat_continue)
+
+        otchet = {"base": args.base, "head": args.head, "merge_base": merge_base, "files": otchet_fajlov}
+        if report_path:
+            report_path.parent.mkdir(parents=True, exist_ok=True)
+            report_path.write_text(
+                json.dumps(otchet, ensure_ascii=False, indent=2), encoding="utf-8"
+            )
+        print(json.dumps(otchet, ensure_ascii=False, indent=2))
+        return 0
+    except GitCommandError as oshibka:
+        print(oshibka, file=sys.stderr)
+        return oshibka.returncode or 1
+    except Exception as oshibka:
+        print(oshibka, file=sys.stderr)
+        return 1
 
 
 if __name__ == "__main__":

--- a/tests/test_resolve_conflicts.py
+++ b/tests/test_resolve_conflicts.py
@@ -1,0 +1,106 @@
+"""Тесты для автоматического резолвера конфликтов."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "resolve_conflicts.py"
+
+
+def run_git(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+
+
+def test_resolve_conflicts_rebase_auto_resolution(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    run_git(repo, "init", "-b", "main")
+    run_git(repo, "config", "user.name", "Pytest User")
+    run_git(repo, "config", "user.email", "pytest@example.com")
+
+    file_path = repo / "note.txt"
+    file_path.write_text("start\nbase\n", encoding="utf-8")
+    run_git(repo, "add", "note.txt")
+    run_git(repo, "commit", "-m", "base commit")
+
+    run_git(repo, "checkout", "-b", "feature")
+    file_path.write_text("start\nfeature\n", encoding="utf-8")
+    run_git(repo, "commit", "-am", "feature change")
+
+    run_git(repo, "checkout", "main")
+    file_path.write_text("start\nmain\n", encoding="utf-8")
+    run_git(repo, "commit", "-am", "main change")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT_PATH),
+            "--base",
+            "main",
+            "--head",
+            "feature",
+            "--report",
+            "report.json",
+        ],
+        cwd=repo,
+        text=True,
+        capture_output=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+    report_path = repo / "report.json"
+    assert report_path.exists()
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    assert report["base"] == "main"
+    assert report["head"] == "feature"
+    assert report["merge_base"], "ожидается вычисленный merge-base"
+    statuses = {entry["status"] for entry in report["files"]}
+    assert "resolved" in statuses
+
+    content = file_path.read_text(encoding="utf-8")
+    assert "feature" in content and "main" in content
+
+    head_branch = run_git(repo, "rev-parse", "--abbrev-ref", "HEAD").stdout.strip()
+    assert head_branch == "feature"
+    status_lines = [line.strip() for line in run_git(repo, "status", "--porcelain").stdout.splitlines() if line.strip()]
+    assert not status_lines or status_lines == ["?? report.json"]
+
+
+def test_resolve_conflicts_invalid_head_returns_nonzero(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    run_git(repo, "init", "-b", "main")
+    run_git(repo, "config", "user.name", "Pytest User")
+    run_git(repo, "config", "user.email", "pytest@example.com")
+
+    (repo / "README.md").write_text("hello\n", encoding="utf-8")
+    run_git(repo, "add", "README.md")
+    run_git(repo, "commit", "-m", "init")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT_PATH),
+            "--base",
+            "main",
+            "--head",
+            "missing-branch",
+        ],
+        cwd=repo,
+        text=True,
+        capture_output=True,
+    )
+
+    assert result.returncode != 0
+    assert "missing-branch" in result.stderr


### PR DESCRIPTION
## Summary
- extend `scripts/resolve_conflicts.py` with explicit base/head arguments, automated rebase handling, and structured reporting
- refresh conflict resolution docs and workflow configuration to document and consume the new script behaviour
- cover the resolver with pytest-based integration tests built on a temporary git repository

## Testing
- pytest tests/test_resolve_conflicts.py

------
https://chatgpt.com/codex/tasks/task_e_68dbf65b5e148323b70cc80b1c11e987