### PR TITLE
Enhance conflict resolver heuristics

### DIFF
--- a/docs/conflict_resolution.md
+++ b/docs/conflict_resolution.md
@@ -9,6 +9,7 @@
 1. Обновите ссылки на удалённые ветки: `git fetch --all --prune`.
 2. Запустите автоматизированный скрипт: `python scripts/resolve_conflicts.py --base origin/main --head work`.
 3. Изучите сгенерированный JSON-отчёт в `build/conflict-report.json`, убедитесь, что все файлы промаркированы как `resolved`.
+   > Примечание. Скрипт читает глобы `files/prefer_ours` и `files/prefer_theirs` из `AGENTS.md`: для совпадающих путей блок `ours` или `theirs` выбирается автоматически. Если соответствий нет, сохраняются обе версии, как и раньше. Решения по каждому конфликту попадают в лог (`resolve_conflicts`) и в отчёт через поле `strategy` (`ours`, `theirs`, `both`). При отсутствии перевода строки в одном из блоков добавляется только разделительный `\n`, чтобы не изменять конец файла лишний раз.
 4. Выполните `make`, `make test`, `./kolibri.sh up` для проверки целостности и работоспособности.
 5. Просмотрите дифф и зафиксируйте изменения коммитом с пометкой `[autofix conflicts]`.
 
@@ -36,6 +37,7 @@ This guide captures the recommended sequence for resolving merge conflicts while
 1. Refresh remotes: `git fetch --all --prune`.
 2. Run the helper: `python scripts/resolve_conflicts.py --base origin/main --head work`.
 3. Inspect the generated report `build/conflict-report.json` and verify that every entry is marked `resolved`.
+   > Note. The resolver reads the `files/prefer_ours` and `files/prefer_theirs` globs from `AGENTS.md` and automatically keeps the matching `ours` or `theirs` side. Unmatched files retain both versions, preserving the previous behaviour. Each decision is logged via the `resolve_conflicts` logger and stored in the report as `strategy` (`ours`, `theirs`, `both`). When a conflict chunk lacks a trailing newline, only a separator `\n` is added to avoid rewriting the file tail.
 4. Execute `make`, `make test`, and `./kolibri.sh up` to validate the fix.
 5. Review the diff and create a commit tagged `[autofix conflicts]` once satisfied.
 
@@ -63,6 +65,7 @@ This guide captures the recommended sequence for resolving merge conflicts while
 1. 刷新远端：`git fetch --all --prune`。
 2. 运行辅助脚本：`python scripts/resolve_conflicts.py --base origin/main --head work`。
 3. 查看 `build/conflict-report.json`，确认所有条目标记为 `resolved`。
+   > 注意：脚本会读取 `AGENTS.md` 中 `files/prefer_ours` / `files/prefer_theirs` 的路径模式，对匹配的文件自动保留 `ours` 或 `theirs` 版本；未命中的文件仍会像之前一样保留双方内容。每个冲突的选择会写入 `resolve_conflicts` 日志，并通过 `strategy` 字段（`ours`、`theirs`、`both`）体现在报告里。若冲突块缺少结尾换行，工具只会在必要时补充分隔 `\n`，避免无谓地改写文件尾部。
 4. 依次执行 `make`、`make test`、`./kolibri.sh up` 验证修复结果。
 5. 检查差异并在满意后创建带有 `[autofix conflicts]` 标记的提交。
 

--- a/scripts/resolve_conflicts.py
+++ b/scripts/resolve_conflicts.py
@@ -5,59 +5,231 @@ from __future__ import annotations
 
 import argparse
 import json
+import logging
 import sys
+from fnmatch import fnmatch
 from pathlib import Path
-from typing import Dict, List
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple
+from scripts.policy_validate import zagruzit_blok
 
 KONFLIKT_START = "<<<<<<<"
 KONFLIKT_DELIM = "======="
 KONFLIKT_END = ">>>>>>>"
 
+LOGGER = logging.getLogger("resolve_conflicts")
 
-def razobrat_konflikt(lines: List[str]) -> List[str]:
-    """Объединяет конфликтные блоки, оставляя обе версии без маркеров."""
+
+def postroit_pravila(root: Path) -> List[Tuple[str, str]]:
+    """Считывает AGENTS.md и возвращает список правил для путей."""
+
+    agent = root / "AGENTS.md"
+    if not agent.exists():
+        return []
+
+    try:
+        blok = zagruzit_blok(agent)
+    except SystemExit:
+        return []
+
+    sektsiya_files = _izvlech_files_sektsiyu(blok)
+    if not sektsiya_files:
+        return []
+
+    pravila: List[Tuple[str, str]] = []
+    for pattern in sektsiya_files.get("prefer_ours", []):
+        pravila.append((pattern, "ours"))
+    for pattern in sektsiya_files.get("prefer_theirs", []):
+        pravila.append((pattern, "theirs"))
+    return pravila
+
+
+def _izvlech_files_sektsiyu(blok: str) -> Dict[str, List[str]]:
+    """Извлекает из текстового блока раздел files и списки шаблонов."""
+
+    sektsiya: Dict[str, List[str]] = {"prefer_ours": [], "prefer_theirs": []}
+    tekushchaya_gruppa: Optional[str] = None
+    v_files = False
+
+    for syraja in blok.splitlines():
+        stroka = syraja.rstrip()
+        if not stroka:
+            continue
+
+        bez_otstupa = stroka.lstrip()
+        otstup = len(stroka) - len(bez_otstupa)
+
+        if not v_files:
+            if bez_otstupa == "files:":
+                v_files = True
+            continue
+
+        if otstup == 0 and not bez_otstupa.startswith("-") and bez_otstupa != "files:":
+            break
+
+        if otstup >= 2 and bez_otstupa.endswith(":"):
+            tekushchaya_gruppa = bez_otstupa[:-1].strip()
+            if tekushchaya_gruppa not in sektsiya:
+                sektsiya[tekushchaya_gruppa] = []
+            continue
+
+        if tekushchaya_gruppa and bez_otstupa.startswith("-"):
+            sektsiya.setdefault(tekushchaya_gruppa, []).append(bez_otstupa[1:].strip())
+
+    return sektsiya
+
+
+def vybrat_po_pravilam(
+    file_path: Path, root: Path, pravila: Sequence[Tuple[str, str]]
+) -> Optional[str]:
+    """Возвращает предпочтительную стратегию для файла согласно правилам."""
+
+    try:
+        otnositelnyj = file_path.relative_to(root)
+    except ValueError:
+        otnositelnyj = file_path
+
+    file_str = otnositelnyj.as_posix()
+    for obrazec, strategiya in pravila:
+        if fnmatch(file_str, obrazec):
+            return strategiya
+    return None
+
+
+def _najti_marker(stroka: str) -> Tuple[int, Optional[str]]:
+    """Ищет ближайший конфликтный маркер в строке."""
+
+    luchshij_indeks = len(stroka)
+    vybrannyj_marker: Optional[str] = None
+    for marker in (KONFLIKT_START, KONFLIKT_DELIM, KONFLIKT_END):
+        indeks = stroka.find(marker)
+        if indeks != -1 and indeks < luchshij_indeks:
+            luchshij_indeks = indeks
+            vybrannyj_marker = marker
+    if vybrannyj_marker is None:
+        return -1, None
+    return luchshij_indeks, vybrannyj_marker
+
+
+def _propustit_marker_stroki(stroka: str, marker: str) -> str:
+    """Удаляет маркер и сопутствующую служебную информацию, возвращая остаток строки."""
+
+    ostatok = stroka[len(marker) :]
+    if not ostatok:
+        return ""
+    ostatok = ostatok.lstrip()
+    if marker in (KONFLIKT_START, KONFLIKT_END) and ostatok:
+        chasti = ostatok.split(None, 1)
+        if len(chasti) == 2:
+            ostatok = chasti[1]
+        else:
+            ostatok = ""
+    if ostatok.startswith("\n"):
+        ostatok = ostatok[1:]
+    return ostatok
+
+
+def razobrat_konflikt(
+    lines: Iterable[str],
+    file_path: Path,
+    root: Path,
+    pravila: Sequence[Tuple[str, str]],
+) -> Tuple[List[str], List[str]]:
+    """Объединяет конфликтные блоки согласно правилам и возвращает применённые стратегии."""
+
     rezultat: List[str] = []
     ours: List[str] = []
     theirs: List[str] = []
     sostoyanie = "normal"
+    strategii: List[str] = []
+    nomer_konflikta = 0
+
     for stroka in lines:
-        if stroka.startswith(KONFLIKT_START):
-            sostoyanie = "ours"
-            ours = []
-            theirs = []
-            continue
-        if stroka.startswith(KONFLIKT_DELIM):
-            sostoyanie = "theirs"
-            continue
-        if stroka.startswith(KONFLIKT_END):
-            rezultat.extend(ours)
-            if rezultat and rezultat[-1] != "\n":
-                rezultat.append("\n")
-            rezultat.extend(theirs)
-            sostoyanie = "normal"
-            continue
-        if sostoyanie == "ours":
-            ours.append(stroka)
-        elif sostoyanie == "theirs":
-            theirs.append(stroka)
-        else:
-            rezultat.append(stroka)
-    return rezultat
+        current = stroka
+        while current:
+            indeks, marker = _najti_marker(current)
+            if indeks > 0:
+                prefix = current[:indeks]
+                if prefix:
+                    if sostoyanie == "ours":
+                        ours.append(prefix)
+                    elif sostoyanie == "theirs":
+                        theirs.append(prefix)
+                    else:
+                        rezultat.append(prefix)
+                current = current[indeks:]
+                continue
+            if marker is None:
+                if sostoyanie == "ours":
+                    ours.append(current)
+                elif sostoyanie == "theirs":
+                    theirs.append(current)
+                else:
+                    rezultat.append(current)
+                break
+            if marker == KONFLIKT_START:
+                sostoyanie = "ours"
+                ours = []
+                theirs = []
+                nomer_konflikta += 1
+                current = _propustit_marker_stroki(current, KONFLIKT_START)
+                continue
+            if marker == KONFLIKT_DELIM:
+                sostoyanie = "theirs"
+                current = _propustit_marker_stroki(current, KONFLIKT_DELIM)
+                continue
+            if marker == KONFLIKT_END:
+                current = _propustit_marker_stroki(current, KONFLIKT_END)
+                vybor = vybrat_po_pravilam(file_path, root, pravila) or "both"
+                if vybor == "ours":
+                    rezultat.extend(ours)
+                elif vybor == "theirs":
+                    rezultat.extend(theirs)
+                else:
+                    rezultat.extend(ours)
+                    if theirs and ours and not ours[-1].endswith("\n"):
+                        rezultat.append("\n")
+                    rezultat.extend(theirs)
+                strategii.append(vybor)
+                LOGGER.info(
+                    "Conflict in %s (block %d): selected %s",
+                    file_path,
+                    nomer_konflikta,
+                    vybor,
+                )
+                sostoyanie = "normal"
+                continue
+    return rezultat, strategii
 
 
-def obrabotat_fajl(path: Path) -> Dict[str, object]:
+def obrabotat_fajl(
+    path: Path, root: Path, pravila: Sequence[Tuple[str, str]]
+) -> Dict[str, object]:
     """Читает файл, устраняет конфликтные маркеры и возвращает отчёт."""
+
     soderzhimoe = path.read_text(encoding="utf-8")
     if KONFLIKT_START not in soderzhimoe:
-        return {"file": str(path), "status": "clean"}
+        return {"file": str(path), "status": "clean", "strategy": None}
     stroki = soderzhimoe.splitlines(keepends=True)
-    novye = razobrat_konflikt(stroki)
+    novye, strategii = razobrat_konflikt(stroki, path, root, pravila)
     path.write_text("".join(novye), encoding="utf-8")
-    return {"file": str(path), "status": "resolved"}
+    strategiya = obobshit_strategiyu(strategii)
+    return {"file": str(path), "status": "resolved", "strategy": strategiya}
+
+
+def obobshit_strategiyu(strategii: Sequence[str]) -> str:
+    """Определяет итоговую стратегию для файла."""
+
+    unikalnye = set(strategii)
+    if unikalnye == {"ours"}:
+        return "ours"
+    if unikalnye == {"theirs"}:
+        return "theirs"
+    return "both"
 
 
 def nayti_fajly(root: Path) -> List[Path]:
     """Возвращает список отслеживаемых файлов с потенциальными конфликтами."""
+
     return [
         path
         for path in root.rglob("*")
@@ -67,12 +239,14 @@ def nayti_fajly(root: Path) -> List[Path]:
 
 def postroit_otchet(root: Path) -> Dict[str, object]:
     """Формирует итоговый отчёт по всем обработанным файлам."""
+
     rezultaty: List[Dict[str, object]] = []
+    pravila = postroit_pravila(root)
     for fajl in nayti_fajly(root):
         try:
-            rezultaty.append(obrabotat_fajl(fajl))
+            rezultaty.append(obrabotat_fajl(fajl, root, pravila))
         except UnicodeDecodeError:
-            rezultaty.append({"file": str(fajl), "status": "skipped"})
+            rezultaty.append({"file": str(fajl), "status": "skipped", "strategy": None})
     return {"files": rezultaty}
 
 
@@ -80,6 +254,7 @@ def main(argv: List[str]) -> int:
     parser = argparse.ArgumentParser(description="Автоконфликт Kolibri")
     parser.add_argument("--report", type=Path, default=None, help="путь для JSON-отчёта")
     args = parser.parse_args(argv)
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
     koren = Path.cwd()
     otchet = postroit_otchet(koren)
     if args.report:

--- a/tests/test_resolve_conflicts.py
+++ b/tests/test_resolve_conflicts.py
@@ -1,0 +1,125 @@
+import logging
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if ROOT.name == "tests":
+    ROOT = ROOT.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts.resolve_conflicts import (  # noqa: E402
+    KONFLIKT_DELIM,
+    KONFLIKT_END,
+    KONFLIKT_START,
+    postroit_otchet,
+)
+
+
+@pytest.fixture
+def agents_content() -> str:
+    return (
+        """```kolibri-policy
+build: ours
+code: ours
+docs: ours
+
+files:
+  prefer_ours:
+    - scripts/**
+  prefer_theirs:
+    - docs/**
+
+budgets:
+  wasm_max_kb: 1
+  step_latency_ms: 1
+  coverage_min_lines: 1
+  coverage_min_branches: 1
+```"""
+    )
+
+
+def zapisat_conflict(
+    path: Path,
+    ours: List[str],
+    theirs: List[str],
+    *,
+    ours_final_newline: bool = True,
+    theirs_final_newline: bool = True,
+    tail: Optional[str] = "epilogue\n",
+) -> None:
+    lines = ["prelude\n", f"{KONFLIKT_START} ours\n"]
+    for index, stroka in enumerate(ours):
+        konec = "\n" if index < len(ours) - 1 or ours_final_newline else ""
+        lines.append(f"{stroka}{konec}")
+    lines.append(f"{KONFLIKT_DELIM}\n")
+    for index, stroka in enumerate(theirs):
+        konec = "\n" if index < len(theirs) - 1 or theirs_final_newline else ""
+        lines.append(f"{stroka}{konec}")
+    konec_marker = "\n" if theirs_final_newline else ""
+    lines.append(f"{KONFLIKT_END} theirs{konec_marker}")
+    if tail is not None:
+        lines.append(tail)
+    path.write_text("".join(lines), encoding="utf-8")
+
+
+def test_prefers_ours_strategy(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture, agents_content: str
+) -> None:
+    (tmp_path / "AGENTS.md").write_text(agents_content, encoding="utf-8")
+    conflict = tmp_path / "scripts" / "example.txt"
+    conflict.parent.mkdir(parents=True)
+    zapisat_conflict(conflict, ["ours-line"], ["theirs-line"])
+
+    caplog.set_level(logging.INFO, logger="resolve_conflicts")
+    report = postroit_otchet(tmp_path)
+
+    assert conflict.read_text(encoding="utf-8") == "prelude\nours-line\nepilogue\n"
+    entry = next(item for item in report["files"] if item["file"] == str(conflict))
+    assert entry["status"] == "resolved"
+    assert entry["strategy"] == "ours"
+    assert any("selected ours" in record.getMessage() for record in caplog.records)
+
+
+def test_fallback_to_both(tmp_path: Path, agents_content: str) -> None:
+    (tmp_path / "AGENTS.md").write_text(agents_content, encoding="utf-8")
+    conflict = tmp_path / "notes.txt"
+    zapisat_conflict(conflict, ["ours"], ["theirs"], theirs_final_newline=False, tail=None)
+
+    report = postroit_otchet(tmp_path)
+
+    result = conflict.read_text(encoding="utf-8")
+    assert result == "prelude\nours\ntheirs"
+    entry = next(item for item in report["files"] if item["file"] == str(conflict))
+    assert entry["strategy"] == "both"
+
+
+def test_prefers_theirs_multiple_conflicts(tmp_path: Path, agents_content: str) -> None:
+    (tmp_path / "AGENTS.md").write_text(agents_content, encoding="utf-8")
+    target = tmp_path / "docs" / "guide.md"
+    target.parent.mkdir(parents=True)
+    text = [
+        "intro\n",
+        f"{KONFLIKT_START} block1\n",
+        "ours-one\n",
+        f"{KONFLIKT_DELIM}\n",
+        "theirs-one\n",
+        f"{KONFLIKT_END} block1\n",
+        "middle\n",
+        f"{KONFLIKT_START} block2\n",
+        "ours-two\n",
+        f"{KONFLIKT_DELIM}\n",
+        "theirs-two",
+        f"{KONFLIKT_END} block2",
+    ]
+    target.write_text("".join(text), encoding="utf-8")
+
+    report = postroit_otchet(tmp_path)
+
+    expected = "intro\ntheirs-one\nmiddle\ntheirs-two"
+    assert target.read_text(encoding="utf-8") == expected
+    entry = next(item for item in report["files"] if item["file"] == str(target))
+    assert entry["strategy"] == "theirs"


### PR DESCRIPTION
## Summary
- load path preferences from AGENTS.md to guide automatic ours/theirs conflict resolution and log selected strategies
- expand JSON reporting with strategy metadata and handle multi-conflict/no-newline blocks when cleaning markers
- add dedicated unit tests plus documentation describing the new heuristics and limitations

## Testing
- `pytest tests/test_resolve_conflicts.py`


------
https://chatgpt.com/codex/tasks/task_e_68dbf65fc3c8832386160ada5d189cf4