### PR TITLE
Fix kolibri_script exports

### DIFF
--- a/core/kolibri_script/__init__.py
+++ b/core/kolibri_script/__init__.py
@@ -43,8 +43,9 @@ __all__ = [
     "VariableDeclaration",
     "WhileStatement",
     "parse_script",
+]
 
-"""Интеграция KolibriScript с цифровым геном и форматами .ksd."""
+# Интеграция KolibriScript с цифровым геном и форматами .ksd.
 
 from .genome import (
     KsdValidationError,
@@ -55,12 +56,11 @@ from .genome import (
     serialize_ksd,
 )
 
-__all__ = [
+__all__ += [
     "KsdValidationError",
     "KolibriGenomeLedger",
     "SecretsConfig",
     "deserialize_ksd",
     "load_secrets_config",
     "serialize_ksd",
-
 ]


### PR DESCRIPTION
## Summary
- close the parser export list so the module docstring is outside of the literal
- extend `__all__` with the genome exports instead of overwriting it

## Testing
- pyright core/kolibri_script/__init__.py

------
https://chatgpt.com/codex/tasks/task_e_68dbf7e0716883239b86b8f075eb129c