### PR TITLE
Align kolibri.sh up flow with developer guide

### DIFF
--- a/scripts/run_cluster.sh
+++ b/scripts/run_cluster.sh
@@ -17,6 +17,7 @@ kolichestvo=3
 bazovyj_port=4100
 prodolzhitelnost=60
 bazovoe_zerno=20250923
+propustit_sborku="${KOLIBRI_CLUSTER_SKIP_BUILD:-0}"
 
 while getopts "n:b:d:s:h" flag; do
     case "$flag" in
@@ -84,8 +85,10 @@ obespechit_klyuch() {
     sozdat_klyuch >"$key_path"
 }
 
-cmake -S "$root_dir" -B "$build_dir" -DCMAKE_EXPORT_COMPILE_COMMANDS=ON >/dev/null
-cmake --build "$build_dir" >/dev/null
+if [ "$propustit_sborku" != "1" ]; then
+    cmake -S "$root_dir" -B "$build_dir" -DCMAKE_EXPORT_COMPILE_COMMANDS=ON >/dev/null
+    cmake --build "$build_dir" >/dev/null
+fi
 
 obespechit_klyuch
 


### PR DESCRIPTION
## Summary
- update `kolibri.sh up` to run the documented build + test + swarm workflow and add a `node` command for single-node launches
- reuse `run_cluster.sh` for the swarm startup and allow it to skip redundant rebuilds via an environment flag

## Testing
- cmake -S . -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
- cmake --build build --target kolibri_tests
- cmake --build build --target ks_compiler
- ctest --test-dir build --output-on-failure


------
https://chatgpt.com/codex/tasks/task_e_68dd749e9d5883239d9f053a0189fcdf