### PR TITLE
Propagate OpenSSL includes to dependent targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ target_include_directories(kolibri_core
 find_package(OpenSSL REQUIRED)
 find_package(Threads REQUIRED)
 
-target_link_libraries(kolibri_core PRIVATE OpenSSL::Crypto)
+target_link_libraries(kolibri_core PUBLIC OpenSSL::Crypto)
 
 add_executable(kolibri_node apps/kolibri_node.c)
 add_executable(ks_compiler apps/ks_compiler.c)


### PR DESCRIPTION
## Summary
- expose the OpenSSL crypto dependency of kolibri_core to consumers so their builds can find the headers

## Testing
- cmake --build build
- ctest


------
https://chatgpt.com/codex/tasks/task_e_68dd783d125883239f2fb6ea8ca8ff9d