### PR TITLE
Stream Kolibri genome journal blocks incrementally

### DIFF
--- a/core/kolibri_script/__init__.py
+++ b/core/kolibri_script/__init__.py
@@ -43,10 +43,12 @@ __all__ = [
     "VariableDeclaration",
     "WhileStatement",
     "parse_script",
+]
 
 """Интеграция KolibriScript с цифровым геном и форматами .ksd."""
 
 from .genome import (
+    KsdBlock,
     KsdValidationError,
     KolibriGenomeLedger,
     SecretsConfig,
@@ -56,11 +58,11 @@ from .genome import (
 )
 
 __all__ = [
+    "KsdBlock",
     "KsdValidationError",
     "KolibriGenomeLedger",
     "SecretsConfig",
     "deserialize_ksd",
     "load_secrets_config",
     "serialize_ksd",
-
 ]

--- a/core/kolibri_sim.py
+++ b/core/kolibri_sim.py
@@ -173,7 +173,7 @@ class KolibriSim:
 
         genesis = self._sozdanie_bloka("GENESIS", {"seed": zerno})
         writer = self._genome_writer
-        if writer is not None and not writer.records:
+        if writer is not None and not writer.has_records():
             writer.append(
                 dataclasses.asdict(genesis),
                 {"tip": "GENESIS", "soobshenie": f"seed={zerno}", "metka": time.time()},


### PR DESCRIPTION
## Summary
- keep KolibriGenomeLedger open for append-only writes and expose streaming access to stored records
- extend the KolibriScript genome format with per-block journal metadata and update deserialization helpers
- adapt KolibriSim initialization and tests to the new streaming journal behaviour

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68e5a1b51ca8832388cdf2411f7ed064