### PR TITLE
Add configurable HMAC key loading to Kolibri node

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,20 @@ if(KOLIBRI_ENABLE_TESTS)
              COMMAND ${CMAKE_COMMAND}
                      -Dks_compiler=$<TARGET_FILE:ks_compiler>
                      -P ${CMAKE_CURRENT_BINARY_DIR}/ks_compiler_roundtrip.cmake)
+
+    find_package(Python3 COMPONENTS Interpreter)
+    if(Python3_FOUND)
+        add_test(NAME kolibri_node_custom_key_inline
+                 COMMAND ${Python3_EXECUTABLE}
+                         ${CMAKE_CURRENT_SOURCE_DIR}/tests/run_kolibri_node_hmac.py
+                         $<TARGET_FILE:kolibri_node>
+                         inline)
+        add_test(NAME kolibri_node_custom_key_file
+                 COMMAND ${Python3_EXECUTABLE}
+                         ${CMAKE_CURRENT_SOURCE_DIR}/tests/run_kolibri_node_hmac.py
+                         $<TARGET_FILE:kolibri_node>
+                         file)
+    endif()
 endif()
 
 # === Kolibri digits module wiring ===

--- a/tests/run_kolibri_node_hmac.py
+++ b/tests/run_kolibri_node_hmac.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+def run_with_mode(binary: str, mode: str) -> None:
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp_path = Path(tmp_dir)
+        genome_path = tmp_path / "genome.dat"
+
+        if mode == "inline":
+            key_argument = "custom-inline-secret"
+        elif mode == "file":
+            key_path = tmp_path / "hmac.key"
+            key_path.write_text("file-secret-key\n", encoding="utf-8")
+            key_argument = f"@{key_path}"
+        else:
+            raise SystemExit(f"неизвестный режим: {mode}")
+
+        command = [
+            binary,
+            "--node-id",
+            "9",
+            "--genome",
+            str(genome_path),
+            "--verify-genome",
+            "--hmac-key",
+            key_argument,
+        ]
+
+        process = subprocess.run(
+            command,
+            input=":verify\n:quit\n",
+            text=True,
+            capture_output=True,
+        )
+
+        if process.returncode != 0:
+            sys.stdout.write(process.stdout)
+            sys.stderr.write(process.stderr)
+            raise SystemExit(process.returncode or 1)
+
+        stdout = process.stdout
+        if mode == "inline":
+            if "аргумент" not in stdout:
+                raise SystemExit("ожидалось упоминание аргумента ключа")
+        else:
+            if "файл" not in stdout:
+                raise SystemExit("ожидалось упоминание файла ключа")
+
+
+def main() -> None:
+    if len(sys.argv) != 3:
+        raise SystemExit("использование: run_kolibri_node_hmac.py <binary> <mode>")
+    run_with_mode(sys.argv[1], sys.argv[2])
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add CLI parsing for --hmac-key allowing inline secrets or file-based keys
- load the configured HMAC key into kolibri_node and propagate it to genome operations with detailed logging
- introduce Python-driven integration tests to ensure kolibri_node starts successfully with custom HMAC keys

## Testing
- cmake -S . -B build
- cmake --build build
- ctest --test-dir build


------
https://chatgpt.com/codex/tasks/task_e_68e5a1af92088323a46b3951af8478f7